### PR TITLE
HTTP signature parser and builder legacy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "picky"
-version = "4.5.1"
+version = "4.6.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1243,7 +1243,7 @@ dependencies = [
  "mongodb_cwal 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "picky 4.5.1",
+ "picky 4.6.0",
  "picky-asn1 0.2.1",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "picky"
-version = "4.5.1"
+version = "4.6.0"
 authors = [
     "jtrepanier-devolutions <jtrepanier@devolutions.net>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
+    "François Dubois <fdubois@devolutions.net>",
+    "Richard Markiewicz <rmarkiewicz@devolutions.net>",
 ]
 description = "Portable X.509, Jose and PKI implementation."
 edition = "2018"

--- a/picky/src/http/http_signature.rs
+++ b/picky/src/http/http_signature.rs
@@ -3,7 +3,7 @@ use crate::{
     key::{PrivateKey, PublicKey},
     signature::{SignatureError, SignatureHashType},
 };
-use base64::DecodeError;
+use base64::{DecodeError, URL_SAFE_NO_PAD};
 use snafu::Snafu;
 use std::{
     borrow::Cow,
@@ -189,20 +189,20 @@ impl ToString for HttpSignature {
         let mut acc = Vec::with_capacity(5);
 
         acc.push(format!(
-            "{} {}=\"{}\"",
+            "{} {}={}",
             HTTP_SIGNATURE_HEADER, HTTP_SIGNATURE_KEY_ID, self.key_id
         ));
 
         if let Some(created) = self.created {
-            acc.push(format!("{}=\"{}\"", HTTP_SIGNATURE_CREATED, created));
+            acc.push(format!("{}={}", HTTP_SIGNATURE_CREATED, created));
         }
 
         if let Some(expires) = self.expires {
-            acc.push(format!("{}=\"{}\"", HTTP_SIGNATURE_EXPIRES, expires));
+            acc.push(format!("{}={}", HTTP_SIGNATURE_EXPIRES, expires));
         }
 
         acc.push(format!(
-            "{}=\"{}\"",
+            "{}={}",
             HTTP_SIGNATURE_HEADERS,
             self.headers
                 .iter()
@@ -211,7 +211,7 @@ impl ToString for HttpSignature {
                 .join(" "),
         ));
 
-        acc.push(format!("{}=\"{}\"", HTTP_SIGNATURE_SIGNATURE, self.signature));
+        acc.push(format!("{}={}", HTTP_SIGNATURE_SIGNATURE, self.signature));
 
         acc.join(",")
     }
@@ -517,7 +517,7 @@ impl<'a> HttpSignatureBuilder<'a> {
             headers,
             created,
             expires,
-            signature: base64::encode(&signature_binary),
+            signature: base64::encode_config(&signature_binary, URL_SAFE_NO_PAD),
         })
     }
 }

--- a/picky/src/http/http_signature.rs
+++ b/picky/src/http/http_signature.rs
@@ -213,7 +213,7 @@ impl ToString for HttpSignature {
 
         acc.push(format!("{}=\"{}\"", HTTP_SIGNATURE_SIGNATURE, self.signature));
 
-        acc.join(", ")
+        acc.join(",")
     }
 }
 

--- a/picky/src/http/mod.rs
+++ b/picky/src/http/mod.rs
@@ -83,8 +83,8 @@
 //!
 //! assert_eq!(
 //!     http_signature_str,
-//!     "Signature keyId=\"my-rsa-key\", created=\"1402170695\", \
-//!      headers=\"(request-target) (created) host date cache-control x-emptyheader x-example\", \
+//!     "Signature keyId=\"my-rsa-key\",created=1402170695,\
+//!      headers=\"(request-target) (created) host date cache-control x-emptyheader x-example\",\
 //!      signature=\"QwuxxMSuvCdA5a2cDOjg+1WFEEGa/gD8fWwKm7gah4IUCssrie+bA5sp9wH7Jz8TQYh/XNDRUHKc\
 //!                  0oziBAIy1CsfDQWGRM+pAonfXEJufdt07v/i0OFhj5rBJfoOWPUcJ0cXzu0gs6svNhvimS3h2g30\
 //!                  gsnw1+Qjgv0+5HFwqZH4i+bHzaj0r9vIZZnnk3ecg8O2uOLuG5jCszJU9SBA0ug8l/NrQPJXMhCO\


### PR DESCRIPTION
- builder do not add spaces between fields of the produced signature
- builder do not add quotes on integers (eg: created=2923983 instead of
created="2923983")
- parser supports values with quotes or no quotes at all regardless of
the parameter

That is, produced HTTP signatures by builder are now like:
```
Signature
keyId="my-rsa-key",created=1402170695,headers="(request-target)
(created) date",signature="..."
```

Parser can read anything like above and even weirdly formatted
signatures like:
```
Signature keyId = my-rsa-key, created=
"1402170695",headers=(request-target) (created) date, signature=...
```

You can build a legacy HTTP signature by calling the `legacy` method on the HTTP Signature builder (see legacy test).