### PR TITLE
Version bump from 4.4.0 to 4.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "picky-server"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bson 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-server"
-version = "4.4.0"
+version = "4.5.0"
 authors = [
     "jtrepanier-devolutions <jtrepanier@devolutions.net>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",


### PR DESCRIPTION
4.4.0 has been released. Version bump to 4.5.0 to prepare next cycle