### PR TITLE
Update bumpalo dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "byte-tools"


### PR DESCRIPTION
This fixes a vulnerability reported by `cargo audit`.

```
ID:       RUSTSEC-2020-0006
Crate:    bumpalo
Version:  3.2.0
Date:     2020-03-24
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0006
Title:    Flaw in `realloc` allows reading unknown memory
Solution:  upgrade to >= 3.2.1
Dependency tree: 
bumpalo 3.2.0
└── wasm-bindgen-backend 0.2.59
    └── wasm-bindgen-macro-support 0.2.59
        └── wasm-bindgen-macro 0.2.59
            └── wasm-bindgen 0.2.59
                ├── web-sys 0.3.36
                │   ├── wasm-bindgen-futures 0.4.9
                │   │   └── reqwest 0.10.4
                │   │       └── picky-server 4.5.0
                │   ├── reqwest 0.10.4
                │   └── plotters 0.2.12
                │       └── criterion 0.3.1
                │           └── picky-server 4.5.0
                ├── wasm-bindgen-futures 0.4.9
                ├── reqwest 0.10.4
                ├── plotters 0.2.12
                └── js-sys 0.3.36
                    ├── web-sys 0.3.36
                    ├── wasm-bindgen-futures 0.4.9
                    ├── reqwest 0.10.4
                    └── plotters 0.2.12
```