### PR TITLE
Added PICKY_DB_NAME to be able to specify database name

### DIFF
--- a/picky-server/src/cli.yml
+++ b/picky-server/src/cli.yml
@@ -37,7 +37,12 @@ args:
       long: db-url
       value_name: DB_URL
       help: Url of the database used by the service.
-      long_help: Url on which the listener will listen.
+      takes_value: true
+      empty_values: false
+  - db-name:
+      long: db-name
+      value_name: DB_NAME
+      help: Name of the database used by the service.
       takes_value: true
       empty_values: false
   - api-key:

--- a/picky-server/src/config.rs
+++ b/picky-server/src/config.rs
@@ -21,6 +21,7 @@ const PICKY_SAVE_CERTIFICATE_ENV: &str = "PICKY_SAVE_CERTIFICATE";
 const PICKY_BACKEND_ENV: &str = "PICKY_BACKEND";
 const PICKY_FILE_BACKEND_PATH_ENV: &str = "PICKY_FILE_BACKEND_PATH";
 const PICKY_DATABASE_URL_ENV: &str = "PICKY_DATABASE_URL";
+const PICKY_DATABASE_NAME_ENV: &str = "PICKY_DATABASE_NAME";
 
 const PICKY_ROOT_CERT_ENV: &str = "PICKY_ROOT_CERT";
 const PICKY_ROOT_CERT_PATH_ENV: &str = "PICKY_ROOT_CERT_PATH";
@@ -41,6 +42,10 @@ fn default_picky_realm() -> String {
 
 fn default_database_url() -> String {
     String::from("mongodb://127.0.0.1:27017")
+}
+
+fn default_database_name() -> String {
+    String::from("picky")
 }
 
 fn default_file_backend_path() -> PathBuf {
@@ -119,6 +124,8 @@ pub struct Config {
     pub file_backend_path: PathBuf,
     #[serde(default = "default_database_url")]
     pub database_url: String,
+    #[serde(default = "default_database_name")]
+    pub database_name: String,
 
     #[serde(default)]
     pub root: Option<CertKeyPair>,
@@ -139,6 +146,7 @@ impl Default for Config {
             backend: BackendType::default(),
             file_backend_path: default_file_backend_path(),
             database_url: default_database_url(),
+            database_name: default_database_name(),
             root: None,
             intermediate: None,
             provisioner_public_key: None,
@@ -195,6 +203,10 @@ impl Config {
             self.database_url = v.to_string();
         }
 
+        if let Some(v) = matches.value_of("db-name") {
+            self.database_name = v.to_string();
+        }
+
         if matches.is_present("dump-config") {
             let yaml_conf = serde_yaml::to_string(&self).expect("conf to yaml");
             if let Err(e) = std::fs::write(YAML_CONF_PATH, yaml_conf) {
@@ -230,6 +242,10 @@ impl Config {
 
         if let Ok(val) = env::var(PICKY_DATABASE_URL_ENV) {
             self.database_url = val;
+        }
+
+        if let Ok(val) = env::var(PICKY_DATABASE_NAME_ENV) {
+            self.database_name = val;
         }
 
         if !inject_cert_key_pair(&mut self.root, PICKY_ROOT_CERT_ENV, PICKY_ROOT_KEY_ENV) {

--- a/picky-server/src/db/mongodb/mod.rs
+++ b/picky-server/src/db/mongodb/mod.rs
@@ -112,7 +112,7 @@ pub struct MongoStorage {
 
 impl MongoStorage {
     pub async fn new(config: &Config) -> Self {
-        let db = MongoConnection::new(&config.database_url).expect("build mongo connection");
+        let db = MongoConnection::new(&config.database_url, &config.database_name).expect("build mongo connection");
 
         let storage = MongoStorage {
             mongo_conn: db.clone(),

--- a/picky-server/src/db/mongodb/mongo_connection.rs
+++ b/picky-server/src/db/mongodb/mongo_connection.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 
 const CONNECTION_IDLE_TIMEOUT_SECS: u64 = 600;
 const DB_CONNECTION_TIMEOUT_SECS: u64 = 15;
-const DATABASE_NAME: &str = "picky";
 
 #[derive(Clone)]
 pub struct MongoConnection {
@@ -18,7 +17,7 @@ pub struct MongoConnection {
 }
 
 impl MongoConnection {
-    pub fn new(mongo_url: &str) -> Result<Self, String> {
+    pub fn new(mongo_url: &str, db_name: &str) -> Result<Self, String> {
         let conn_str = connstring::parse(mongo_url).map_err(|e| format!("couldn't parse connection string: {}", e))?;
 
         let mut client_options = match conn_str.options.as_ref().and_then(|options| options.options.get("ssl")) {
@@ -29,7 +28,7 @@ impl MongoConnection {
         client_options.pool_size = Some(1);
         client_options.read_preference = Some(ReadPreference::new(ReadMode::SecondaryPreferred, None));
 
-        let manager = r2d2_mongo::MongoConnectionManager::new(conn_str, DATABASE_NAME, client_options);
+        let manager = r2d2_mongo::MongoConnectionManager::new(conn_str, db_name, client_options);
 
         let pool = r2d2::Pool::builder()
             .max_size(20)


### PR DESCRIPTION
Idem a den-server, il pourrait être pratique de spécifier le nom de la BD a utiliser.  Le défaut demeure picky.