### PR TITLE
Modify RSAPrivateKey to be RFC 8017 compliant

### DIFF
--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -35,9 +35,9 @@ digest = "0.9"
 rsa = "0.3"
 rand = "0.7"
 aes-gcm = { version = "0.6", optional = true }
+num-bigint-dig = "0.6"
 
 [dev-dependencies]
-num-bigint-dig = "0.6"
 pretty_assertions = "^0.6"
 hex = "0.4"
 cfg-if = "0.1"


### PR DESCRIPTION
RFC 8017 can be found here:

    https://tools.ietf.org/html/rfc8017.html

It defines RSA private keys like so:

    RSAPrivateKey ::= SEQUENCE {
        version           Version,
        modulus           INTEGER,  -- n
        publicExponent    INTEGER,  -- e
        privateExponent   INTEGER,  -- d
        prime1            INTEGER,  -- p
        prime2            INTEGER,  -- q
        exponent1         INTEGER,  -- d mod (p-1)
        exponent2         INTEGER,  -- d mod (q-1)
        coefficient       INTEGER,  -- (inverse of q) mod p
        otherPrimeInfos   OtherPrimeInfos OPTIONAL
    }

Previously, the implementation of RSA private keys in picky omitted:
- exponent1
- exponent2
- coefficient
- otherPrimeInfos

This commit modifies the RSAPrivateKey struct to include these fields,
as well as changes the struct to be more runtime safe.