### PR TITLE
picky-server: version bump to 4.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "picky-server"
-version = "4.8.0"
+version = "4.9.0"
 dependencies = [
  "base64 0.12.3",
  "chrono",

--- a/picky-server/CHANGELOG.md
+++ b/picky-server/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [4.8.0] 2020-11-20
+
+### Changed
+
 - Set leaf certificates initial validity 10 minutes ahead current date
 
 ## [4.7.0] 2020-09-22

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-server"
-version = "4.8.0"
+version = "4.9.0"
 authors = [
     "jtrepanier-devolutions <jtrepanier@devolutions.net>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",


### PR DESCRIPTION
Version 4.8.0 released... moving to next version