### PR TITLE
Add extension request support

### DIFF
--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "picky-asn1-x509"
 version = "0.4.0"
-authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
+authors = [
+    "Benoît CORTIER <benoit.cortier@fried-world.eu>",
+    "Sergey Noskov <snoskov@avito.ru>",
+    "Kim Altintop <kim@monadic.xyz>",
+    "Joe Ellis <joe.ellis@arm.com>",
+    "Hugues de Valon <hugues.devalon@arm.com>",
+    "Isode Ltd./Geobert Quach <geobert.quach@isode.com>"
+]
 description = "Provides ASN1 types defined by X.509 related RFCs"
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/picky-asn1-x509/src/certification_request.rs
+++ b/picky-asn1-x509/src/certification_request.rs
@@ -44,7 +44,8 @@ impl CertificationRequestInfo {
     }
 }
 
-// this type is a hack to workaround [this issue](https://github.com/Devolutions/picky-rs/pull/78#issuecomment-789904165).
+// FIXME: this type is a hack to workaround [this issue](https://github.com/Devolutions/picky-rs/pull/78#issuecomment-789904165).
+// Further refactorings are required to clean this up (proper support for IMPLICIT / EXPLICIT tags, etc)
 #[derive(Clone, Debug, PartialEq)]
 pub struct Attributes(pub Vec<Attribute>);
 

--- a/picky-asn1-x509/src/directory_string.rs
+++ b/picky-asn1-x509/src/directory_string.rs
@@ -69,7 +69,7 @@ impl From<PrintableString> for DirectoryString {
 
 impl From<Utf8String> for DirectoryString {
     fn from(string: Utf8String) -> Self {
-        Self::Utf8String(String::from_utf8_lossy(string.as_bytes()).to_string())
+        Self::Utf8String(String::from_utf8(string.into_bytes()).expect("Utf8String has the right charset"))
     }
 }
 

--- a/picky-asn1-x509/src/directory_string.rs
+++ b/picky-asn1-x509/src/directory_string.rs
@@ -1,5 +1,5 @@
 use picky_asn1::{
-    restricted_string::PrintableString,
+    restricted_string::{PrintableString, Utf8String},
     tag::{Tag, TagPeeker},
     wrapper::PrintableStringAsn1,
 };
@@ -64,6 +64,12 @@ impl From<String> for DirectoryString {
 impl From<PrintableString> for DirectoryString {
     fn from(string: PrintableString) -> Self {
         Self::PrintableString(string.into())
+    }
+}
+
+impl From<Utf8String> for DirectoryString {
+    fn from(string: Utf8String) -> Self {
+        Self::Utf8String(String::from_utf8_lossy(string.as_bytes()).to_string())
     }
 }
 

--- a/picky-asn1-x509/src/macros.rs
+++ b/picky-asn1-x509/src/macros.rs
@@ -39,6 +39,7 @@ mod tests {
         };
         ($item:ident: $type:ident in $encoded:ident) => {
             let encoded = &$encoded[..];
+            let encoded_base64 = base64::encode(encoded);
 
             println!(concat!(stringify!($item), " check..."));
 
@@ -47,8 +48,9 @@ mod tests {
                 stringify!($item),
                 " serialization"
             ));
+            let serialized_base64 = base64::encode(&serialized);
             pretty_assertions::assert_eq!(
-                serialized, encoded,
+                serialized_base64, encoded_base64,
                 concat!("serialized ", stringify!($item), " doesn't match")
             );
 

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -107,6 +107,7 @@ define_oid! {
     BASIC_CONSTRAINTS => basic_constraints => "2.5.29.19",
     AUTHORITY_KEY_IDENTIFIER => authority_key_identifier => "2.5.29.35",
     EXTENDED_KEY_USAGE => extended_key_usage => "2.5.29.37",
+    EXTENSION_REQ => extension_request => "1.2.840.113549.1.9.14",
 
     // aes
     // aes-128

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -55,6 +55,7 @@ define_oid! {
     SHA512_WITH_RSA_ENCRYPTION => sha512_with_rsa_encryption => "1.2.840.113549.1.1.13",
     SHA224_WITH_RSA_ENCRYPTION => sha224_with_rsa_encryption => "1.2.840.113549.1.1.14",
     EMAIL_ADDRESS => email_address => "1.2.840.113549.1.9.1", // deprecated
+    EXTENSION_REQ => extension_request => "1.2.840.113549.1.9.14",
 
     // NIST
     DSA_WITH_SHA224 => dsa_with_sha224 => "2.16.840.1.101.3.4.3.1",
@@ -107,7 +108,6 @@ define_oid! {
     BASIC_CONSTRAINTS => basic_constraints => "2.5.29.19",
     AUTHORITY_KEY_IDENTIFIER => authority_key_identifier => "2.5.29.35",
     EXTENDED_KEY_USAGE => extended_key_usage => "2.5.29.37",
-    EXTENSION_REQ => extension_request => "1.2.840.113549.1.9.14",
 
     // aes
     // aes-128

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -6,6 +6,8 @@ authors = [
     "Jonathan Trepanier <jtrepanier@devolutions.net>",
     "François Dubois <fdubois@devolutions.net>",
     "Richard Markiewicz <rmarkiewicz@devolutions.net>",
+    "Ionut Mihalcea <ionut.mihalcea@arm.com>",
+    "Kim Altintop <kim@monadic.xyz>"
 ]
 description = "Portable X.509, PKI, JOSE and HTTP signature implementation."
 keywords = ["x509", "jwt", "signature", "jose", "pki"]


### PR DESCRIPTION
Address #77 , on behalf of Isode Ltd.

Some precision on this PR:

# attributes field type

the `attributes` field ended up being `Implicit<Option<ApplicationTag0<Attribute>>>` instead of 
`Implicit<Option<ApplicationTag0<Asn1SetOf<Attribute>>>>` because after testing the output of openssl, it seems that the Asn1SetOf is not present.

using the attached files, you can use
`openssl req -config req.txt -new -key key.pem -out req.pem` 

to generate the CSR and see that there's no `SET` after `[0]`

I was curious on what's the output of openssl if we add a challengePassword to the request: add `attributes = req_attributes` to the `[ req ]` section and rerun the openssl command, you'll see:

![image](https://user-images.githubusercontent.com/72570/109664159-c52def00-7b64-11eb-85a0-75d7bb09d35b.png)

so after the `[0]`, no `SET` and two consecutive `SEQUENCE`.

We don't need challengePassword yet, but if we add support later, I think `ApplicationTag0` will need some way to have a `SET` without serializing it.

# Unit test

I've added a Unit test for extensions using the config attached and openssl to create the PEM test data.
As attributes has change default value, the `deserialize_csr` test is broken, I think it needs to be updated but I prefer to ask before doing anything on this.
EDIT: maybe it's not the test, but the encoding, I've lost the `[0]` so ignore this point

# Copyright

The legal team of my company is happy to license the contribution under the dual-license MIT-Apache-2.0 but would like to have Isode Ltd. mentioned somewhere. Some crates have a `Contributor.txt` file listing contributors. Would you (and Devolutions) agree to add this file to the repository? It would look like this (header copied from `oxide-auth` crate's repository):
```
# A list of people who have contributed to this project, with optional metadata
# The list is sorted chronologically, excluding the current maintainer who should always be listed first
# Format: Foo Bar <optional mail address> (comment e.g. company affiliation)

Benoît Cortier (current maintainer)
Jonathan Trépanier (on behalf of Devolutions)
Marc-André Moreau (on behalf of Devolutions)
Jean-Francois Theroux
François Dubois
Sébastien Duquette (on behalf of Devolutions)
Johann Dufaud
Richard Markiewicz
Ionuț Mihalcea
Kim Altintop
Joe Ellis
Hugues de Valon
Geobert Quach (on behalf of Isode Ltd.)
```
I took the time to sort the different contributors chronologically :)

# Conclusion and Recap

As the message is quite large, here is a summary on what's left:
- [x] agree on the type of `attributes`
- [ ] fix the unit test `deserialize_csr` because of change of `attributes` type
- [x] agree on adding a contributors list file


[req.zip](https://github.com/Devolutions/picky-rs/files/6069344/req.zip)

