### PR TITLE
Implement picky-signtool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +358,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +408,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "criterion"
@@ -573,6 +609,16 @@ checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
  "syn",
+]
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
 ]
 
 [[package]]
@@ -1094,6 +1140,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1269,27 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "lief-rs"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=c487e1#c487e152a684cfa9c5a0225d958372add5fcd382"
+dependencies = [
+ "bitflags",
+ "image",
+ "lief-sys",
+ "picky 6.2.0",
+ "thiserror",
+ "widestring",
+]
+
+[[package]]
+name = "lief-sys"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=c487e1#c487e152a684cfa9c5a0225d958372add5fcd382"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1328,6 +1410,15 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1579,6 +1670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1848,28 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "picky"
+version = "6.2.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=3834f9#3834f9346e214ca6529a4303d87cc9ce35b775f1"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "digest 0.9.0",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1 0.3.1",
+ "picky-asn1-der 0.2.4",
+ "picky-asn1-x509 0.5.0",
+ "rand 0.8.3",
+ "rsa",
+ "serde",
+ "sha-1 0.9.4",
+ "sha2 0.9.3",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "picky"
 version = "6.3.0"
 dependencies = [
  "aes-gcm",
@@ -1758,9 +1882,9 @@ dependencies = [
  "http",
  "num-bigint-dig",
  "oid",
- "picky-asn1",
- "picky-asn1-der",
- "picky-asn1-x509",
+ "picky-asn1 0.3.2",
+ "picky-asn1-der 0.2.5",
+ "picky-asn1-x509 0.6.0",
  "pretty_assertions",
  "rand 0.8.3",
  "ring",
@@ -1775,11 +1899,31 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
+version = "0.3.1"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=3834f9#3834f9346e214ca6529a4303d87cc9ce35b775f1"
+dependencies = [
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1"
 version = "0.3.2"
 dependencies = [
  "chrono",
  "oid",
- "picky-asn1-der",
+ "picky-asn1-der 0.2.5",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-der"
+version = "0.2.4"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=3834f9#3834f9346e214ca6529a4303d87cc9ce35b775f1"
+dependencies = [
+ "picky-asn1 0.3.1",
  "serde",
  "serde_bytes",
 ]
@@ -1792,10 +1936,24 @@ dependencies = [
  "lazy_static",
  "num-bigint-dig",
  "oid",
- "picky-asn1",
+ "picky-asn1 0.3.2",
  "pretty_assertions",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.5.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=3834f9#3834f9346e214ca6529a4303d87cc9ce35b775f1"
+dependencies = [
+ "base64 0.13.0",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1 0.3.1",
+ "picky-asn1-der 0.2.4",
+ "serde",
+ "widestring",
 ]
 
 [[package]]
@@ -1806,8 +1964,8 @@ dependencies = [
  "hex",
  "num-bigint-dig",
  "oid",
- "picky-asn1",
- "picky-asn1-der",
+ "picky-asn1 0.3.2",
+ "picky-asn1-der 0.2.5",
  "pretty_assertions",
  "serde",
  "widestring",
@@ -1828,8 +1986,8 @@ dependencies = [
  "mongodm",
  "multibase",
  "multihash",
- "picky",
- "picky-asn1",
+ "picky 6.3.0",
+ "picky-asn1 0.3.2",
  "rand 0.8.3",
  "reqwest 0.11.3",
  "saphir",
@@ -1840,6 +1998,16 @@ dependencies = [
  "tokio 0.2.25",
  "tokio-test",
  "unicase",
+]
+
+[[package]]
+name = "picky-signtool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "lief-rs",
+ "picky 6.3.0",
 ]
 
 [[package]]
@@ -1912,6 +2080,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "picky-asn1",
     "picky-asn1-der",
     "picky-asn1-x509",
+    "picky-signtool"
 ]
 
 [patch.crates-io]

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 authors = [
     "KizzyCode Software Labs./Keziah Biermann <development@kizzycode.de>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
+    "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",
 ]
 keywords = ["serde", "asn1", "asn1-der", "serialize", "deserialize"]
 categories = ["encoding"]

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -7,7 +7,8 @@ authors = [
     "Kim Altintop <kim@monadic.xyz>",
     "Joe Ellis <joe.ellis@arm.com>",
     "Hugues de Valon <hugues.devalon@arm.com>",
-    "Isode Ltd./Geobert Quach <geobert.quach@isode.com>"
+    "Isode Ltd./Geobert Quach <geobert.quach@isode.com>",
+    "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",
 ]
 description = "Provides ASN1 types defined by X.509 related RFCs"
 edition = "2018"

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.2"
 edition = "2018"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
+    "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",
 ]
 keywords = ["serde", "asn1", "serialize", "deserialize"]
 categories = ["encoding"]

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "picky-signtool"
+version = "0.1.0"
+authors = [ "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>" ]
+edition = "2018"
+description = "A signtool like Authenticode sign and verify tool based on picky and lief-rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = "2.33"
+lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "c487e1" }
+
+[dependencies.picky]
+path = "../picky"
+default-features = false
+features = ["wincert"]

--- a/picky-signtool/src/main.rs
+++ b/picky-signtool/src/main.rs
@@ -1,0 +1,212 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use clap::{crate_authors, crate_description, crate_name, crate_version, App, Arg, ArgMatches};
+use lief::{Binary, LogLevel, VerificationChecks};
+
+const ARG_INPUT: &str = "input";
+const ARG_OUTPUT: &str = "output";
+const ARG_SIGN: &str = "sign";
+const ARG_CERTFILE: &str = "certfile";
+const ARG_PRIVATE_KEY: &str = "private-key";
+
+const ARG_VERIFY: &str = "verify";
+const ARG_VERIFY_DEFAULT: &str = "default";
+const ARG_VERIFY_HASH_ONLY: &str = "hash-only";
+const ARG_VERIFY_LIFETIME_SIGNING: &str = "lifetime-signing";
+const ARG_VERIFY_SKIP_CERT_TIME: &str = "skip-cert-time";
+
+const ARG_LOGGING: &str = "logging";
+const ARG_LOGGING_TRACE: &str = "trace";
+const ARG_LOGGING_DEBUG: &str = "debug";
+const ARG_LOGGING_INFO: &str = "info";
+const ARG_LOGGING_WARN: &str = "warn";
+const ARG_LOGGING_ERR: &str = "err";
+const ARG_LOGGING_CRITICAL: &str = "critical";
+
+fn main() -> anyhow::Result<()> {
+    let matches = config();
+
+    match matches.value_of(ARG_LOGGING) {
+        Some(log_level) => {
+            let log_level = match log_level {
+                ARG_LOGGING_TRACE => LogLevel::LogTrace,
+                ARG_LOGGING_DEBUG => LogLevel::LogDebug,
+                ARG_LOGGING_INFO => LogLevel::LogInfo,
+                ARG_LOGGING_WARN => LogLevel::LogWarn,
+                ARG_LOGGING_ERR => LogLevel::LogErr,
+                ARG_LOGGING_CRITICAL => LogLevel::LogCritical,
+                _ => unreachable!("Unexpected log level value"),
+            };
+            lief::enable_logging(log_level);
+        }
+
+        None => lief::disable_logging(),
+    }
+
+    let binary_path = matches
+        .value_of(ARG_INPUT)
+        .expect("Path to a Windows executable is required");
+
+    let binary_path = PathBuf::from(binary_path);
+    let binary_name = binary_path
+        .as_path()
+        .file_name()
+        .map(|name| name.to_str())
+        .flatten()
+        .map(|name| name.to_owned())
+        .expect("file name should be present");
+
+    let binary = Binary::new(binary_path).map_err(|err| anyhow!("Failed to load the executable: {}", err))?;
+
+    if let Some(verification_checks) = matches.value_of(ARG_VERIFY) {
+        let check_flag = match verification_checks {
+            ARG_VERIFY_DEFAULT => VerificationChecks::DEFAULT,
+            ARG_VERIFY_HASH_ONLY => VerificationChecks::HASH_ONLY,
+            ARG_VERIFY_LIFETIME_SIGNING => VerificationChecks::LIFETIME_SIGNING,
+            ARG_VERIFY_SKIP_CERT_TIME => VerificationChecks::SKIP_CERT_TIME,
+            _ => unreachable!("Unexpected verification option"),
+        };
+
+        let check_result = binary
+            .check_signature(check_flag)
+            .map_err(|err| anyhow!("Failed to check signature: {}", err))?;
+
+        println!("Verify the executable signature result: {:?}", check_result);
+    }
+
+    if matches.is_present(ARG_SIGN) {
+        if let (Some(certfile), Some(private_key), Some(output_path)) = (
+            matches.value_of(ARG_CERTFILE),
+            matches.value_of(ARG_PRIVATE_KEY),
+            matches.value_of(ARG_OUTPUT),
+        ) {
+            let certfile = read_file_into_vec(PathBuf::from(certfile))?;
+            let private_key = read_file_into_vec(PathBuf::from(private_key))?;
+
+            binary
+                .set_authenticode(certfile, private_key, Some(binary_name.clone()))
+                .map_err(|err| anyhow!("Failed to check signature: {}", err))?;
+
+            binary
+                .build(PathBuf::from(output_path), false)
+                .map_err(|err| anyhow!("Failed to build the signed executable: {}", err))?;
+
+            println!("Signed {} successfully!", binary_name);
+        }
+    }
+
+    Ok(())
+}
+
+fn config() -> ArgMatches<'static> {
+    let validate_executable_postfix =
+        |file: String| match Path::new(file.as_str()).extension().map(|ext| ext.to_str()).flatten() {
+            Some("exe") => Ok(()),
+            _ => Err(String::from("The input file is not an Windows executable")),
+        };
+
+    App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .arg(
+            Arg::with_name(ARG_INPUT)
+                .short("i")
+                .long(ARG_INPUT)
+                .value_name("EXECUTABLE")
+                .help("Path to a Windows executable")
+                .takes_value(true)
+                .required(true)
+                .validator(validate_executable_postfix)
+                .display_order(0),
+        )
+        .arg(
+            Arg::with_name(ARG_OUTPUT)
+                .short("o")
+                .long(ARG_OUTPUT)
+                .value_name("EXECUTABLE")
+                .help("Path where to save the signed binary")
+                .takes_value(true)
+                .validator(validate_executable_postfix)
+                .display_order(1),
+        )
+        .arg(
+            Arg::with_name(ARG_SIGN)
+                .short(ARG_SIGN)
+                .long("sign")
+                .help("Sign the input file")
+                .requires_all(&[ARG_CERTFILE, ARG_PRIVATE_KEY, ARG_OUTPUT])
+                .display_order(2),
+        )
+        .arg(
+            Arg::with_name(ARG_CERTFILE)
+                .short("cert")
+                .long(ARG_CERTFILE)
+                .value_name("CERTIFICATE")
+                .help("Path to a PKCS7 certificate to use in signing")
+                .takes_value(true)
+                .display_order(3),
+        )
+        .arg(
+            Arg::with_name(ARG_PRIVATE_KEY)
+                .short("key")
+                .long(ARG_PRIVATE_KEY)
+                .value_name("PRIVATE_KEY")
+                .help("The private key associated with the certificate")
+                .takes_value(true)
+                .display_order(4),
+        )
+        .arg(
+            Arg::with_name(ARG_VERIFY)
+                .short("v")
+                .long(ARG_VERIFY)
+                .value_name("FLAG")
+                .help("Verify input file")
+                .long_help(format!("`{}` - {}\n`{}` - {}\n`{}` - {}\n`{}` - {}\n",
+                                     ARG_VERIFY_DEFAULT, "Default behavior that tries to follow the Microsoft verification process as close as possible",
+                                     ARG_VERIFY_HASH_ONLY, "Only check that Binary::authentihash matches ContentInfo::digest regardless of the signature's validity",
+                                     ARG_VERIFY_LIFETIME_SIGNING, "Same semantic as [WTD_LIFETIME_SIGNING_FLAG](https://docs.microsoft.com/en-us/windows/win32/api/wintrust/ns-wintrust-wintrust_data#WTD_LIFETIME_SIGNING_FLAG)",
+                                     ARG_VERIFY_SKIP_CERT_TIME, "Skip the verification of the certificates time validities so that even though a certificate expired, it returns VERIFICATION_FLAGS::OK)",
+                ).as_str())
+                .possible_values(&[
+                    ARG_VERIFY_DEFAULT,
+                    ARG_VERIFY_HASH_ONLY,
+                    ARG_VERIFY_LIFETIME_SIGNING,
+                    ARG_VERIFY_SKIP_CERT_TIME,
+                ])
+                .display_order(5),
+        )
+        .arg(
+            Arg::with_name(ARG_LOGGING)
+                .short("l")
+                .long(ARG_LOGGING)
+                .value_name("LOG_LEVEL")
+                .help("Turn on logging with provided level")
+                .takes_value(true)
+                .possible_values(&[
+                    ARG_LOGGING_TRACE,
+                    ARG_LOGGING_DEBUG,
+                    ARG_LOGGING_INFO,
+                    ARG_LOGGING_WARN,
+                    ARG_LOGGING_ERR,
+                    ARG_LOGGING_CRITICAL,
+                ])
+                .display_order(6),
+        )
+        .set_term_width(190)
+        .get_matches()
+}
+
+fn read_file_into_vec(file: PathBuf) -> anyhow::Result<Vec<u8>> {
+    let mut file = File::open(file.as_path()).map_err(|err| anyhow!("Failed to open {:?}: `{}`", file, err))?;
+
+    let mut data = Vec::new();
+
+    file.read_to_end(&mut data)
+        .map_err(|err| anyhow!("Failed to read file: {}", err))?;
+
+    Ok(data)
+}

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -7,7 +7,8 @@ authors = [
     "François Dubois <fdubois@devolutions.net>",
     "Richard Markiewicz <rmarkiewicz@devolutions.net>",
     "Ionut Mihalcea <ionut.mihalcea@arm.com>",
-    "Kim Altintop <kim@monadic.xyz>"
+    "Kim Altintop <kim@monadic.xyz>",
+    "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",
 ]
 description = "Portable X.509, PKI, JOSE and HTTP signature implementation."
 keywords = ["x509", "jwt", "signature", "jose", "pki"]


### PR DESCRIPTION
picky-signtool uses picky Authenticode implementation and lief-rs for embedding an Authenticode signature to the target binary.   