### PR TITLE
Stopgap fix for #91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ dependencies = [
  "http",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.3.3",
+ "picky-asn1 0.4.0",
  "picky-asn1-der 0.2.5",
  "picky-asn1-x509 0.6.1",
  "pretty_assertions",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "oid",
@@ -1936,7 +1936,7 @@ dependencies = [
  "lazy_static",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.3.3",
+ "picky-asn1 0.4.0",
  "pretty_assertions",
  "serde",
  "serde_bytes",
@@ -1964,7 +1964,7 @@ dependencies = [
  "hex",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.3.3",
+ "picky-asn1 0.4.0",
  "picky-asn1-der 0.2.5",
  "pretty_assertions",
  "serde",
@@ -1987,7 +1987,7 @@ dependencies = [
  "multibase",
  "multihash",
  "picky 6.3.0",
- "picky-asn1 0.3.3",
+ "picky-asn1 0.4.0",
  "rand 0.8.3",
  "reqwest 0.11.3",
  "saphir",

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_bytes = "0.11"
 lazy_static = { version = "1.4", optional = true }

--- a/picky-asn1-der/src/raw_der.rs
+++ b/picky-asn1-der/src/raw_der.rs
@@ -62,14 +62,14 @@ impl Asn1RawDer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use picky_asn1::wrapper::ApplicationTag0;
+    use picky_asn1::wrapper::ExplicitContextTag0;
 
     #[test]
     fn raw_der_behind_application_tag() {
-        let encoded = crate::to_vec(&ApplicationTag0(Asn1RawDer(vec![0x02, 0x01, 0x07]))).expect("to vec");
+        let encoded = crate::to_vec(&ExplicitContextTag0(Asn1RawDer(vec![0x02, 0x01, 0x07]))).expect("to vec");
         pretty_assertions::assert_eq!(encoded.as_slice(), [0xA0, 0x03, 0x02, 0x01, 0x07]);
 
-        let decoded: ApplicationTag0<Asn1RawDer> = crate::from_bytes(&encoded).expect("from bytes");
+        let decoded: ExplicitContextTag0<Asn1RawDer> = crate::from_bytes(&encoded).expect("from bytes");
         pretty_assertions::assert_eq!((decoded.0).0.as_slice(), [0x02, 0x01, 0x07]);
     }
 }

--- a/picky-asn1-der/src/ser/mod.rs
+++ b/picky-asn1-der/src/ser/mod.rs
@@ -114,7 +114,9 @@ impl<'se> Serializer<'se> {
     fn h_write_header(&mut self, tag: Tag, len: usize) -> Result<usize> {
         let mut written;
         match self.encapsulators.last() {
-            Some(last_encapsulator_tag) if last_encapsulator_tag.is_context_specific() && last_encapsulator_tag.is_primitive() => {
+            Some(last_encapsulator_tag)
+                if last_encapsulator_tag.is_context_specific() && last_encapsulator_tag.is_primitive() =>
+            {
                 written = self.h_write_encapsulator(len)?;
             }
             _ => {

--- a/picky-asn1-der/src/ser/mod.rs
+++ b/picky-asn1-der/src/ser/mod.rs
@@ -84,7 +84,7 @@ impl<'se> Serializer<'se> {
         let mut written = 0;
 
         for (i, encapsulator_tag) in self.encapsulators.iter().copied().enumerate() {
-            written += self.writer.write_one(encapsulator_tag.number())?;
+            written += self.writer.write_one(encapsulator_tag.inner())?;
 
             let encapsulated_len = {
                 let mut encapsulated_len = payload_len;
@@ -114,7 +114,7 @@ impl<'se> Serializer<'se> {
     fn h_write_header(&mut self, tag: Tag, len: usize) -> Result<usize> {
         let mut written;
         match self.encapsulators.last() {
-            Some(last_encapsulator_tag) if last_encapsulator_tag.is_context_specific() => {
+            Some(last_encapsulator_tag) if last_encapsulator_tag.is_context_specific() && last_encapsulator_tag.is_primitive() => {
                 written = self.h_write_encapsulator(len)?;
             }
             _ => {
@@ -122,7 +122,7 @@ impl<'se> Serializer<'se> {
                     written = self.h_write_encapsulator(len)?;
                 } else {
                     written = self.h_write_encapsulator(Length::encoded_len(len) + len + 1)?;
-                    written += self.writer.write_one(tag.number())?;
+                    written += self.writer.write_one(tag.inner())?;
                     written += Length::serialize(len, &mut self.writer)?;
                 }
             }
@@ -286,38 +286,38 @@ impl<'a, 'se> serde::ser::Serializer for &'a mut Serializer<'se> {
             Asn1SequenceOf::<()>::NAME => self.tag_for_next_seq = Tag::SEQUENCE,
             BitStringAsn1Container::<()>::NAME => self.h_encapsulate(Tag::BIT_STRING),
             OctetStringAsn1Container::<()>::NAME => self.h_encapsulate(Tag::OCTET_STRING),
-            ApplicationTag0::<()>::NAME => self.h_encapsulate(Tag::APP_0),
-            ApplicationTag1::<()>::NAME => self.h_encapsulate(Tag::APP_1),
-            ApplicationTag2::<()>::NAME => self.h_encapsulate(Tag::APP_2),
-            ApplicationTag3::<()>::NAME => self.h_encapsulate(Tag::APP_3),
-            ApplicationTag4::<()>::NAME => self.h_encapsulate(Tag::APP_4),
-            ApplicationTag5::<()>::NAME => self.h_encapsulate(Tag::APP_5),
-            ApplicationTag6::<()>::NAME => self.h_encapsulate(Tag::APP_6),
-            ApplicationTag7::<()>::NAME => self.h_encapsulate(Tag::APP_7),
-            ApplicationTag8::<()>::NAME => self.h_encapsulate(Tag::APP_8),
-            ApplicationTag9::<()>::NAME => self.h_encapsulate(Tag::APP_9),
-            ApplicationTag10::<()>::NAME => self.h_encapsulate(Tag::APP_10),
-            ApplicationTag11::<()>::NAME => self.h_encapsulate(Tag::APP_11),
-            ApplicationTag12::<()>::NAME => self.h_encapsulate(Tag::APP_12),
-            ApplicationTag13::<()>::NAME => self.h_encapsulate(Tag::APP_13),
-            ApplicationTag14::<()>::NAME => self.h_encapsulate(Tag::APP_14),
-            ApplicationTag15::<()>::NAME => self.h_encapsulate(Tag::APP_15),
-            ContextTag0::<()>::NAME => self.h_encapsulate(Tag::CTX_0),
-            ContextTag1::<()>::NAME => self.h_encapsulate(Tag::CTX_1),
-            ContextTag2::<()>::NAME => self.h_encapsulate(Tag::CTX_2),
-            ContextTag3::<()>::NAME => self.h_encapsulate(Tag::CTX_3),
-            ContextTag4::<()>::NAME => self.h_encapsulate(Tag::CTX_4),
-            ContextTag5::<()>::NAME => self.h_encapsulate(Tag::CTX_5),
-            ContextTag6::<()>::NAME => self.h_encapsulate(Tag::CTX_6),
-            ContextTag7::<()>::NAME => self.h_encapsulate(Tag::CTX_7),
-            ContextTag8::<()>::NAME => self.h_encapsulate(Tag::CTX_8),
-            ContextTag9::<()>::NAME => self.h_encapsulate(Tag::CTX_9),
-            ContextTag10::<()>::NAME => self.h_encapsulate(Tag::CTX_10),
-            ContextTag11::<()>::NAME => self.h_encapsulate(Tag::CTX_11),
-            ContextTag12::<()>::NAME => self.h_encapsulate(Tag::CTX_12),
-            ContextTag13::<()>::NAME => self.h_encapsulate(Tag::CTX_13),
-            ContextTag14::<()>::NAME => self.h_encapsulate(Tag::CTX_14),
-            ContextTag15::<()>::NAME => self.h_encapsulate(Tag::CTX_15),
+            ExplicitContextTag0::<()>::NAME => self.h_encapsulate(ExplicitContextTag0::<()>::TAG),
+            ExplicitContextTag1::<()>::NAME => self.h_encapsulate(ExplicitContextTag1::<()>::TAG),
+            ExplicitContextTag2::<()>::NAME => self.h_encapsulate(ExplicitContextTag2::<()>::TAG),
+            ExplicitContextTag3::<()>::NAME => self.h_encapsulate(ExplicitContextTag3::<()>::TAG),
+            ExplicitContextTag4::<()>::NAME => self.h_encapsulate(ExplicitContextTag4::<()>::TAG),
+            ExplicitContextTag5::<()>::NAME => self.h_encapsulate(ExplicitContextTag5::<()>::TAG),
+            ExplicitContextTag6::<()>::NAME => self.h_encapsulate(ExplicitContextTag6::<()>::TAG),
+            ExplicitContextTag7::<()>::NAME => self.h_encapsulate(ExplicitContextTag7::<()>::TAG),
+            ExplicitContextTag8::<()>::NAME => self.h_encapsulate(ExplicitContextTag8::<()>::TAG),
+            ExplicitContextTag9::<()>::NAME => self.h_encapsulate(ExplicitContextTag9::<()>::TAG),
+            ExplicitContextTag10::<()>::NAME => self.h_encapsulate(ExplicitContextTag10::<()>::TAG),
+            ExplicitContextTag11::<()>::NAME => self.h_encapsulate(ExplicitContextTag11::<()>::TAG),
+            ExplicitContextTag12::<()>::NAME => self.h_encapsulate(ExplicitContextTag12::<()>::TAG),
+            ExplicitContextTag13::<()>::NAME => self.h_encapsulate(ExplicitContextTag13::<()>::TAG),
+            ExplicitContextTag14::<()>::NAME => self.h_encapsulate(ExplicitContextTag14::<()>::TAG),
+            ExplicitContextTag15::<()>::NAME => self.h_encapsulate(ExplicitContextTag15::<()>::TAG),
+            ImplicitContextTag0::<()>::NAME => self.h_encapsulate(ImplicitContextTag0::<()>::TAG),
+            ImplicitContextTag1::<()>::NAME => self.h_encapsulate(ImplicitContextTag1::<()>::TAG),
+            ImplicitContextTag2::<()>::NAME => self.h_encapsulate(ImplicitContextTag2::<()>::TAG),
+            ImplicitContextTag3::<()>::NAME => self.h_encapsulate(ImplicitContextTag3::<()>::TAG),
+            ImplicitContextTag4::<()>::NAME => self.h_encapsulate(ImplicitContextTag4::<()>::TAG),
+            ImplicitContextTag5::<()>::NAME => self.h_encapsulate(ImplicitContextTag5::<()>::TAG),
+            ImplicitContextTag6::<()>::NAME => self.h_encapsulate(ImplicitContextTag6::<()>::TAG),
+            ImplicitContextTag7::<()>::NAME => self.h_encapsulate(ImplicitContextTag7::<()>::TAG),
+            ImplicitContextTag8::<()>::NAME => self.h_encapsulate(ImplicitContextTag8::<()>::TAG),
+            ImplicitContextTag9::<()>::NAME => self.h_encapsulate(ImplicitContextTag9::<()>::TAG),
+            ImplicitContextTag10::<()>::NAME => self.h_encapsulate(ImplicitContextTag10::<()>::TAG),
+            ImplicitContextTag11::<()>::NAME => self.h_encapsulate(ImplicitContextTag11::<()>::TAG),
+            ImplicitContextTag12::<()>::NAME => self.h_encapsulate(ImplicitContextTag12::<()>::TAG),
+            ImplicitContextTag13::<()>::NAME => self.h_encapsulate(ImplicitContextTag13::<()>::TAG),
+            ImplicitContextTag14::<()>::NAME => self.h_encapsulate(ImplicitContextTag14::<()>::TAG),
+            ImplicitContextTag15::<()>::NAME => self.h_encapsulate(ImplicitContextTag15::<()>::TAG),
             HeaderOnly::<()>::NAME => self.no_header = true,
             Asn1RawDer::NAME => self.no_header = true,
             _ => {}

--- a/picky-asn1-der/tests/pki_tests/version.rs
+++ b/picky-asn1-der/tests/pki_tests/version.rs
@@ -1,4 +1,4 @@
-use picky_asn1::wrapper::{ApplicationTag0, Implicit};
+use picky_asn1::wrapper::{ExplicitContextTag0, Optional};
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 
@@ -74,11 +74,11 @@ impl<'de> Deserialize<'de> for Version {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct OptionalVersionTestStruct {
     #[serde(skip_serializing_if = "implicit_app0_version_is_default")]
-    version: Implicit<ApplicationTag0<Version>>,
+    version: Optional<ExplicitContextTag0<Version>>,
     other_non_optional_integer: u8,
 }
 
-pub fn implicit_app0_version_is_default(version: &Implicit<ApplicationTag0<Version>>) -> bool {
+pub fn implicit_app0_version_is_default(version: &Optional<ExplicitContextTag0<Version>>) -> bool {
     version.is_default()
 }
 
@@ -87,7 +87,7 @@ fn optional_version() {
     let buffer_with_version: [u8; 10] = [0x30, 0x08, 0xA0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x01, 0x6E];
 
     let non_default = OptionalVersionTestStruct {
-        version: ApplicationTag0(Version::V3).into(),
+        version: ExplicitContextTag0(Version::V3).into(),
         other_non_optional_integer: 0x6E,
     };
 
@@ -96,7 +96,7 @@ fn optional_version() {
     let buffer_without_version: [u8; 5] = [0x30, 0x03, 0x02, 0x01, 0x6E];
 
     let default = OptionalVersionTestStruct {
-        version: ApplicationTag0(Version::default()).into(),
+        version: ExplicitContextTag0(Version::default()).into(),
         other_non_optional_integer: 0x6E,
     };
 

--- a/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
+++ b/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
@@ -62,8 +62,8 @@ use oid::prelude::*;
 use picky_asn1::bit_string::BitString;
 use picky_asn1::date::Date;
 use picky_asn1::wrapper::{
-    ExplicitContextTag0, ExplicitContextTag3, Asn1SequenceOf, Asn1SetOf, BitStringAsn1, Optional, IntegerAsn1,
-    ObjectIdentifierAsn1, OctetStringAsn1, UTCTimeAsn1,
+    Asn1SequenceOf, Asn1SetOf, BitStringAsn1, ExplicitContextTag0, ExplicitContextTag3, IntegerAsn1,
+    ObjectIdentifierAsn1, OctetStringAsn1, Optional, UTCTimeAsn1,
 };
 use serde::{Deserialize, Serialize};
 

--- a/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
+++ b/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
@@ -62,7 +62,7 @@ use oid::prelude::*;
 use picky_asn1::bit_string::BitString;
 use picky_asn1::date::Date;
 use picky_asn1::wrapper::{
-    ApplicationTag0, ApplicationTag3, Asn1SequenceOf, Asn1SetOf, BitStringAsn1, Implicit, IntegerAsn1,
+    ExplicitContextTag0, ExplicitContextTag3, Asn1SequenceOf, Asn1SetOf, BitStringAsn1, Optional, IntegerAsn1,
     ObjectIdentifierAsn1, OctetStringAsn1, UTCTimeAsn1,
 };
 use serde::{Deserialize, Serialize};
@@ -77,14 +77,14 @@ struct Certificate {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct TbsCertificate {
     #[serde(skip_serializing_if = "implicit_app0_version_is_default")]
-    pub version: Implicit<ApplicationTag0<Version>>,
+    pub version: Optional<ExplicitContextTag0<Version>>,
     pub serial_number: u128,
     pub signature: AlgorithmIdentifier,
     pub issuer: Name,
     pub validity: Validity,
     pub subject: Name,
     pub subject_public_key_info: SubjectPublicKeyInfoRsa,
-    pub extensions: ApplicationTag3<Extensions>,
+    pub extensions: ExplicitContextTag3<Extensions>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -107,7 +107,7 @@ pub struct Extensions(Vec<Extension>);
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Extension {
     extn_id: ObjectIdentifierAsn1,
-    critical: Implicit<Option<bool>>,
+    critical: Optional<Option<bool>>,
     extn_value: OctetStringAsn1,
 }
 
@@ -212,7 +212,7 @@ fn x509_v3_certificate() {
     // TbsCertificate
 
     let tbs_certificate = TbsCertificate {
-        version: ApplicationTag0(Version::V3).into(),
+        version: ExplicitContextTag0(Version::V3).into(),
         serial_number: 935548868,
         signature: AlgorithmIdentifier {
             algorithm: ObjectIdentifier::try_from("1.2.840.113549.1.1.11").unwrap().into(), // sha256
@@ -222,7 +222,7 @@ fn x509_v3_certificate() {
         validity,
         subject,
         subject_public_key_info,
-        extensions: ApplicationTag3(extensions),
+        extensions: ExplicitContextTag3(extensions),
     };
     check!(tbs_certificate: TbsCertificate in encoded[4..522]);
 

--- a/picky-asn1-der/tests/serde_der_advanced_asn1_types.rs
+++ b/picky-asn1-der/tests/serde_der_advanced_asn1_types.rs
@@ -229,7 +229,7 @@ fn sequence_of() {
 #[test]
 fn application_tag0() {
     let buffer = [0xA0, 0x03, 0x02, 0x01, 0xF9];
-    let application_tag = ApplicationTag0(IntegerAsn1::from((-7).to_bigint().unwrap().to_signed_bytes_be()));
+    let application_tag = ExplicitContextTag0(IntegerAsn1::from((-7).to_bigint().unwrap().to_signed_bytes_be()));
     check(&buffer, application_tag);
 }
 
@@ -251,6 +251,6 @@ fn restricted_strings() {
 #[test]
 fn nested_encapsulators() {
     let buffer = [0xA1, 0x5, 0xA4, 0x3, 0x02, 0x01, 0x05];
-    let expected = ApplicationTag1(ApplicationTag4(u8::from(5)));
+    let expected = ExplicitContextTag1(ExplicitContextTag4(u8::from(5)));
     check(&buffer, expected);
 }

--- a/picky-asn1-der/tests/serde_der_sequence.rs
+++ b/picky-asn1-der/tests/serde_der_sequence.rs
@@ -39,7 +39,7 @@ fn test() {
 #[test]
 fn test_err() {
     // Invalid tag
-    let der = b"\xFF\x15\x02\x01\x07\x04\x09\x54\x65\x73\x74\x6f\x6c\x6f\x70\x65\x30\x05\x02\x01\x04\x05\x00";
+    let der = b"\x1F\x15\x02\x01\x07\x04\x09\x54\x65\x73\x74\x6f\x6c\x6f\x70\x65\x30\x05\x02\x01\x04\x05\x00";
     match from_bytes::<TestStruct>(der) {
         Err(Asn1DerError::InvalidData) => (),
         result => panic!("invalid tag => invalid result: {:?}", result),

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
-picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.2", path = "../picky-asn1-der" }
 serde = { version = "1.0", features = ["derive"] }
 oid = { version = "0.2", features = ["serde_support"] }

--- a/picky-asn1-x509/src/pkcs7.rs
+++ b/picky-asn1-x509/src/pkcs7.rs
@@ -7,13 +7,13 @@ pub mod signer_info;
 use crate::oids;
 use signed_data::SignedData;
 
-use picky_asn1::wrapper::{ApplicationTag0, ObjectIdentifierAsn1};
+use picky_asn1::wrapper::{ExplicitContextTag0, ObjectIdentifierAsn1};
 use serde::{de, Serialize};
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
 pub struct Pkcs7Certificate {
     pub oid: ObjectIdentifierAsn1,
-    pub signed_data: ApplicationTag0<SignedData>,
+    pub signed_data: ExplicitContextTag0<SignedData>,
 }
 
 impl<'de> de::Deserialize<'de> for Pkcs7Certificate {
@@ -39,7 +39,7 @@ impl<'de> de::Deserialize<'de> for Pkcs7Certificate {
                 let oid: ObjectIdentifierAsn1 =
                     seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
 
-                let signed_data: ApplicationTag0<SignedData> = match Into::<String>::into(&oid.0).as_str() {
+                let signed_data: ExplicitContextTag0<SignedData> = match Into::<String>::into(&oid.0).as_str() {
                     oids::SIGNED_DATA => seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?,
                     _ => {
                         return Err(serde_invalid_value!(

--- a/picky-asn1-x509/src/pkcs7/content_info.rs
+++ b/picky-asn1-x509/src/pkcs7/content_info.rs
@@ -204,7 +204,7 @@ impl<'de> de::Deserialize<'de> for SpcAttributeAndOptionalValue {
 #[derive(Serialize, Debug, PartialEq, Clone)]
 pub struct SpcPeImageData {
     pub flags: SpcPeImageFlags,
-    pub file: ExplicitContextTag0<SpcLink>, // According to Authenticode_PE.docx, there is  no ApplicationTag0, but otherwise created Authenticode signature won't be valid
+    pub file: ExplicitContextTag0<SpcLink>, // According to Authenticode_PE.docx, there is  no ExplicitContextTag0, but otherwise created Authenticode signature won't be valid
 }
 
 impl<'de> de::Deserialize<'de> for SpcPeImageData {

--- a/picky-asn1-x509/src/pkcs7/signed_data.rs
+++ b/picky-asn1-x509/src/pkcs7/signed_data.rs
@@ -48,7 +48,7 @@ pub struct SignersInfos(pub Asn1SetOf<SignerInfo>);
 #[derive(Debug, PartialEq, Clone)]
 pub struct CertificateSet(pub Vec<Certificate>);
 
-// This is a workaround for consturcted encoding as implicit
+// This is a workaround for constructed encoding as implicit
 
 impl ser::Serialize for CertificateSet {
     fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, <S as ser::Serializer>::Error>

--- a/picky-asn1-x509/src/version.rs
+++ b/picky-asn1-x509/src/version.rs
@@ -71,17 +71,17 @@ impl<'de> Deserialize<'de> for Version {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use picky_asn1::wrapper::{ApplicationTag9, Implicit};
+    use picky_asn1::wrapper::{ExplicitContextTag9, Optional};
     use picky_asn1_der::Asn1DerError;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct OptionalVersionTestStruct {
         #[serde(skip_serializing_if = "version_is_default")]
-        version: Implicit<ApplicationTag9<Version>>,
+        version: Optional<ExplicitContextTag9<Version>>,
         other_non_optional_integer: u8,
     }
 
-    fn version_is_default(version: &Implicit<ApplicationTag9<Version>>) -> bool {
+    fn version_is_default(version: &Optional<ExplicitContextTag9<Version>>) -> bool {
         (version.0).0 == Version::V1
     }
 
@@ -90,7 +90,7 @@ mod tests {
         let buffer_with_version: [u8; 10] = [0x30, 0x08, 0xA9, 0x03, 0x02, 0x01, 0x02, 0x02, 0x01, 0x6E];
 
         let non_default = OptionalVersionTestStruct {
-            version: ApplicationTag9(Version::V3).into(),
+            version: ExplicitContextTag9(Version::V3).into(),
             other_non_optional_integer: 0x6E,
         };
 
@@ -99,7 +99,7 @@ mod tests {
         let buffer_without_version: [u8; 5] = [0x30, 0x03, 0x02, 0x01, 0x6E];
 
         let default = OptionalVersionTestStruct {
-            version: ApplicationTag9(Version::default()).into(),
+            version: ExplicitContextTag9(Version::default()).into(),
             other_non_optional_integer: 0x6E,
         };
 

--- a/picky-asn1/CHANGELOG.md
+++ b/picky-asn1/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## [0.4.0] 2021-08-09
+
+### Changed
+
+- Rename `Tag::number` into `Tag::inner`
+- Rename `ApplicationTag{0-15}` into `ExplicitContextTag{0-15}`
+- Rename `ContextTag{0-15}` into `ImplicitContextTag{0-15}`
+- Rename `Implicit` into `Optional`
+
+### Added
+
+- `Tag::is_primitive`
+- `Tag::application_primitive`
+- `Tag::application_constructed`
+- `Tag::context_specific_primitive`
+- `Tag::context_specific_constructed`
+- `Tag::number`
+- `Tag::class`
+- `Tag::class_and_number`
+- `Tag::components`
+- `Tag::is_application`
+- `Tag::is_context_specific`
+- `Tag::is_universal`
+- `Tag::is_private`
+- `Tag::is_constructed`
+- `Tag::is_primitive`
+- `Tag::encoding`
+- `TagClass`
+- `Encoding`
+
+### Removed
+
+- `Tag::APP_{0-15}`
+- `Tag::CTX_{0-15}`
+- `Tag::application`
+- `Tag::context_specific`
+
 ## [0.3.3] 2021-07-02
 
 ### Fixed

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2018"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
 picky = { version = "6.3.0", default-features = false, features = ["x509", "jose", "chrono_conversion"], path = "../picky" }
-picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 mongodm = { version = "0.6", features = ["tokio-runtime"] }
 clap = { features = ["yaml"], version = "2.32" }
 saphir = { version = "2.7", features = ["macro"] }

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/Devolutions/picky-rs"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.2", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.6", path = "../picky-asn1-x509", features = ["legacy"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/picky/src/x509/certificate.rs
+++ b/picky/src/x509/certificate.rs
@@ -8,7 +8,7 @@ use crate::x509::date::UTCDate;
 use crate::x509::key_id_gen_method::{KeyIdGenError, KeyIdGenMethod};
 use crate::x509::name::{DirectoryName, GeneralNames};
 use picky_asn1::bit_string::BitString;
-use picky_asn1::wrapper::{ApplicationTag0, ApplicationTag3, IntegerAsn1};
+use picky_asn1::wrapper::{ExplicitContextTag0, ExplicitContextTag3, IntegerAsn1};
 use picky_asn1_der::Asn1DerError;
 use picky_asn1_x509::{
     oids, AlgorithmIdentifier, AuthorityKeyIdentifier, BasicConstraints, Certificate, ExtendedKeyUsage, Extension,
@@ -799,11 +799,7 @@ impl<'a> CertificateBuilder<'a> {
             SubjectInfos::Csr(csr) => {
                 csr.verify().map_err(|e| CertError::InvalidCsr { source: e })?;
 
-                let ext_req = csr
-                    .0
-                    .certification_request_info
-                    .attributes
-                    .0
+                let ext_req = ((csr.0.certification_request_info.attributes.0).0)
                     .into_iter()
                     .find_map(|attr| match attr.value {
                         picky_asn1_x509::AttributeValues::Extensions(set_of_extensions) => {
@@ -902,14 +898,14 @@ impl<'a> CertificateBuilder<'a> {
         };
 
         let tbs_certificate = TbsCertificate {
-            version: ApplicationTag0(Version::V3),
+            version: ExplicitContextTag0(Version::V3),
             serial_number,
             signature: AlgorithmIdentifier::from(signature_hash_type),
             issuer: Name::from(issuer_name),
             validity,
             subject: Name::from(subject_name),
             subject_public_key_info: SubjectPublicKeyInfo::from(subject_public_key),
-            extensions: ApplicationTag3(extensions),
+            extensions: ExplicitContextTag3(extensions),
         };
 
         let tbs_der = picky_asn1_der::to_vec(&tbs_certificate)

--- a/picky/src/x509/wincert.rs
+++ b/picky/src/x509/wincert.rs
@@ -5,9 +5,7 @@ use crate::x509::extension::{ExtendedKeyUsage, ExtensionView};
 use crate::x509::pkcs7::{Pkcs7, Pkcs7Error};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use picky_asn1::tag::Tag;
-use picky_asn1::wrapper::{
-    Asn1SequenceOf, Asn1SetOf, ExplicitContextTag0, ExplicitContextTag1, ImplicitContextTag0, Optional,
-};
+use picky_asn1::wrapper::{Asn1SetOf, ExplicitContextTag0, ExplicitContextTag1, Optional};
 use picky_asn1_x509::algorithm_identifier::AlgorithmIdentifier;
 use picky_asn1_x509::pkcs7::cmsversion::CmsVersion;
 use picky_asn1_x509::pkcs7::content_info::{
@@ -27,6 +25,7 @@ use std::error;
 use std::io::{self, BufReader, BufWriter};
 use thiserror::Error;
 
+use picky_asn1_x509::signer_info::Attributes;
 pub use picky_asn1_x509::ShaVariant;
 
 const MINIMUM_BYTES_TO_DECODE: usize = 4 /* WinCertificate::length */ + 2 /* WinCertificate::revision */ + 2 /* WinCertificate::certificate */;
@@ -188,7 +187,7 @@ impl WinCertificate {
             version: CmsVersion::V1,
             sid: SignerIdentifier::IssuerAndSerialNumber(issuer_and_serial_number),
             digest_algorithm: DigestAlgorithmIdentifier(digest_algorithm.clone()),
-            signed_attrs: Optional(ImplicitContextTag0(Asn1SequenceOf(authenticated_attributes))),
+            signed_attrs: Optional(Attributes(authenticated_attributes)),
             signature_algorithm: SignatureAlgorithmIdentifier(AlgorithmIdentifier::new_rsa_encryption()),
             signature: encrypted_digest,
         };


### PR DESCRIPTION
Fix weird context-tag class.

- Remove `Tag::APP_{0-15}`
- Remove `Tag::CTX_{0-15}`
- Remove `Tag::application`
- Remove `Tag::context_specific`
- Rename `Tag::number` into `Tag::inner`
- Rename `ApplicationTag{0-15}` into `ExplicitContextTag{0-15}`
- Rename `ContextTag{0-15}` into `ImplicitContextTag{0-15}`
- Rename `Implicit` into `Optional`
- Add `Tag::is_primitive`
- Add `Tag::application_primitive`
- Add `Tag::application_constructed`
- Add `Tag::context_specific_primitive`
- Add `Tag::context_specific_constructed`
- Add `Tag::number`
- Add `Tag::class`
- Add `Tag::class_and_number`
- Add `Tag::components`
- Add `Tag::is_application`
- Add `Tag::is_context_specific`
- Add `Tag::is_universal`
- Add `Tag::is_private`
- Add `Tag::is_constructed`
- Add `Tag::is_primitive`
- Add `Tag::encoding`
- Add `TagClass`
- Add `Encoding`

cc @Albibek

@RRRadicalEdward this cleans a bit picky internals, but I have one last issue with a test in `picky::x509::wincert`, do you have an idea?
For for details enable `debug_log` feature of `picky-asn1-der` in `picky/Cargo.toml` and run `cargo test`

```
[…]
| debug => | | | | | | | | | | | | | | | | deserialize_newtype_struct: ObjectIdentifierAsn1
| debug => | | | | | | | | | | | | | | | | | deserialize_bytes
| debug => | | | | | | | | | | | | | | | | | | object read: OBJECT IDENTIFIER (len = 9)
| debug => | | | | | | | | | | | | | | | | | | | object buffer: [60, 86, 48, 01, 65, 03, 04, 02, 01]
| debug => | | | | | | | | | | | | | | | | deserialize_unit
| debug => | | | | | | | | | | | | | | | | | object read: NULL (len = 0)
| debug => | | | | | | | | | | | | | | | | | | object buffer: []
| debug => | | | | | | | | | | | | | deserialize_newtype_struct: Optional
| debug => | | | | | | | | | | | | | | deserialize_newtype_struct: ImplicitContextTag0
| debug => | | | | | | | | | | | | | | | CONTEXT_SPECIFIC(00) PRIMITIVE pushed as encapsulator
| debug => | | | | | | | | | | | | | | | deserialize_newtype_struct: Asn1SequenceOf
| debug => | | | | | | | | | | | | | | | | deserialize_seq
| debug => | | | | | | | | | | | | | | | | | tag: SEQUENCE, len: 25
| debug => | | | | | | | | | | | | | | | | | | deserialize_seq
| debug => | | | | | | | | | | | | | | | | | | | tag: OBJECT IDENTIFIER, len: 9
| debug => | | | | | | | | | | | | | | | | | | | | deserialize_seq: INVALID (found OBJECT IDENTIFIER)
| debug => | | | | | | | | | | | | | deserialize_newtype_struct: SignatureAlgorithmIdentifier
| debug => | | | | | | | | | | | | | | deserialize_seq
| debug => | | | | | | | | | | | | | | | tag: UNIVERSAL(0A) CONSTRUCTED, len: 79744507642121
| debug => | | | | | | | | | | | | | | | | deserialize_newtype_struct: ObjectIdentifierAsn1
| debug => | | | | | | | | | | | | | | | | | deserialize_bytes
| debug => | | | | | | | | | | | | | | | | | | object read: BIT STRING (len = 49)
| debug => | | | | | | | | | | | | | | | | | | | object buffer: [0C, 06, 0A, 2B, 06, 01, 04, 01, 82, 37, 02, 01, 04, 30, 7A, 06, 0A, 2B, 06, 01, 04, 01, 82, 37, 02, 01, 0C, 31, 6C, 30, 6A, A0, 46, 80, 44, 00, 64, 00, 65, 00, 63, 00, 6F, 00, 64, 00, 69, 00, 6E]
thread 'x509::wincert::tests::decoding_into_win_certificate' panicked at 'called `Result::unwrap()` on an `Err` value: Message("invalid value: [AlgorithmIdentifier] unsupported algorithm (unknown oid), expected a supported algorithm")', picky/src/x509/wincert.rs:526:105
```

Something is clearly wrong something (notably because of the `tag: UNIVERSAL(0A) CONSTRUCTED, len: 79744507642121`)