### PR TITLE
Authenticode timestamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,12 +1399,12 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "lief-rs"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/lief-rs.git?rev=797f33#797f3395a806c1a003039d80cc84ccbb6d382770"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=8f439c#8f439c2397035eb5e1d72277dd12eb0717930d67"
 dependencies = [
  "bitflags",
  "image",
  "lief-sys",
- "picky 6.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
+ "picky 6.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "thiserror",
  "widestring",
 ]
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "lief-sys"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/lief-rs.git?rev=797f33#797f3395a806c1a003039d80cc84ccbb6d382770"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=8f439c#8f439c2397035eb5e1d72277dd12eb0717930d67"
 dependencies = [
  "cmake",
 ]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "picky"
 version = "6.4.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef#610a4ef4d570e7b965f49a95a25b389763c5fe56"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
 dependencies = [
  "aes-gcm",
  "base64 0.13.0",
@@ -2025,9 +2025,9 @@ dependencies = [
  "md-5 0.9.1",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
- "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
- "picky-asn1-x509 0.6.1 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
+ "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
+ "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
+ "picky-asn1-x509 0.6.1 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "rand 0.8.3",
  "rsa",
  "serde",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "picky-asn1"
 version = "0.4.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef#610a4ef4d570e7b965f49a95a25b389763c5fe56"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
 dependencies = [
  "oid",
  "serde",
@@ -2076,9 +2076,9 @@ dependencies = [
 [[package]]
 name = "picky-asn1-der"
 version = "0.2.5"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef#610a4ef4d570e7b965f49a95a25b389763c5fe56"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
 dependencies = [
- "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
+ "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "serde",
  "serde_bytes",
 ]
@@ -2101,13 +2101,13 @@ dependencies = [
 [[package]]
 name = "picky-asn1-x509"
 version = "0.6.1"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef#610a4ef4d570e7b965f49a95a25b389763c5fe56"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
 dependencies = [
  "base64 0.13.0",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
- "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=610a4ef)",
+ "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
+ "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "serde",
  "widestring",
 ]

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -12,11 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Authenticode timestamp deserialization/serialization
 - CTL implementation behind `ctl` feature
 - New `SpcSipInfo` struct
+- Add serialization/deserialization of Authenticode `TimestampRequest`. 
+- Add timestamp request oid.
+- Add a few methods for creating an Attribute without usage low-level API:
+  - `Attribute::new_content_type_pkcs7`
+  - `Attribute::new_signing_time`
+  - `Attribute::new_message_digest`
+- Add `EncapsulatedContentInfo::new_pkcs7_data` method.
 
 ### Changed
 
 - (Breaking) `ShaVariant` enum is extended for MD5 and SH1 algorithms
 - (Breaking) Add `SpcStatementType` variant in `AttributeValues` enum
+- (Breaking) Add `SigningTime` variant in `AttributeValues` enum
 - `SpcAttributeAndOptionalValue` now supports both `SpcPeImageData` and `SpcSipInfo` values
 
 ### Fixed

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added 
+### Added
 
 - Support for Authenticode timestamp deserialization/serialization
 - CTL implementation behind `ctl` feature
 - New `SpcSipInfo` struct
-- Add serialization/deserialization of Authenticode `TimestampRequest`. 
-- Add timestamp request oid.
+- Add serialization/deserialization of Authenticode `TimestampRequest`
+- Add timestamp request OID
 - Add a few methods for creating an Attribute without usage low-level API:
   - `Attribute::new_content_type_pkcs7`
   - `Attribute::new_signing_time`
   - `Attribute::new_message_digest`
-- Add `EncapsulatedContentInfo::new_pkcs7_data` method.
+- Add `EncapsulatedContentInfo::new_pkcs7_data` method
 
 ### Changed
 

--- a/picky-asn1-x509/src/attribute.rs
+++ b/picky-asn1-x509/src/attribute.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "pkcs7")]
 use crate::pkcs7::content_info::SpcSpOpusInfo;
 use crate::{oids, Extension, Extensions};
-use picky_asn1::wrapper::{Asn1SequenceOf, Asn1SetOf, ObjectIdentifierAsn1, OctetStringAsn1};
+use picky_asn1::date::UTCTime;
+use picky_asn1::wrapper::{Asn1SequenceOf, Asn1SetOf, ObjectIdentifierAsn1, OctetStringAsn1, UTCTimeAsn1};
 use serde::{de, ser};
 
 pub type Attributes = Asn1SequenceOf<Attribute>;
@@ -13,7 +14,7 @@ pub type Attributes = Asn1SequenceOf<Attribute>;
 ///
 /// `spcSpOpusInfo` is behind the `pkcs7` feature.
 ///
-/// `contentType`, `messageDigest` and `spcSpOpusInfo` are used for [microsoft authenticode]
+/// `contentType`, `messageDigest`, `spcSpOpusInfo` and `SigningTime` are used for [microsoft authenticode]
 /// (http://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/Authenticode_PE.docx)
 #[derive(Clone, Debug, PartialEq)]
 pub enum AttributeValues {
@@ -24,6 +25,7 @@ pub enum AttributeValues {
     ContentType(Asn1SetOf<ObjectIdentifierAsn1>),
     SpcStatementType(Asn1SetOf<Asn1SequenceOf<ObjectIdentifierAsn1>>),
     MessageDigest(Asn1SetOf<OctetStringAsn1>),
+    SigningTime(Asn1SetOf<UTCTimeAsn1>),
     #[cfg(feature = "pkcs7")]
     SpcSpOpusInfo(Asn1SetOf<SpcSpOpusInfo>),
     Custom(picky_asn1_der::Asn1RawDer), // fallback
@@ -42,6 +44,27 @@ impl Attribute {
             value: AttributeValues::Extensions(Asn1SetOf(vec![Extensions(extensions)])),
         }
     }
+
+    pub fn new_content_type_pkcs7() -> Self {
+        Self {
+            ty: oids::content_type().into(),
+            value: AttributeValues::ContentType(vec![oids::pkcs7().into()].into()),
+        }
+    }
+
+    pub fn new_signing_time(signing_time: UTCTime) -> Self {
+        Self {
+            ty: oids::signing_time().into(),
+            value: AttributeValues::SigningTime(vec![signing_time.into()].into()),
+        }
+    }
+
+    pub fn new_message_digest(digest: Vec<u8>) -> Self {
+        Self {
+            ty: oids::message_digest().into(),
+            value: AttributeValues::MessageDigest(vec![digest.into()].into()),
+        }
+    }
 }
 
 impl ser::Serialize for Attribute {
@@ -57,6 +80,7 @@ impl ser::Serialize for Attribute {
             AttributeValues::Custom(der) => seq.serialize_element(der)?,
             AttributeValues::ContentType(oid) => seq.serialize_element(oid)?,
             AttributeValues::MessageDigest(octet_string) => seq.serialize_element(octet_string)?,
+            AttributeValues::SigningTime(signing_time) => seq.serialize_element(signing_time)?,
             #[cfg(feature = "pkcs7")]
             AttributeValues::SpcSpOpusInfo(spc_sp_opus_info) => seq.serialize_element(spc_sp_opus_info)?,
             AttributeValues::SpcStatementType(spc_statement_type) => seq.serialize_element(spc_statement_type)?,
@@ -97,6 +121,7 @@ impl<'de> de::Deserialize<'de> for Attribute {
                     oids::MESSAGE_DIGEST => {
                         AttributeValues::MessageDigest(seq_next_element!(seq, Attribute, "an octet string"))
                     }
+                    oids::SIGNING_TIME => AttributeValues::SigningTime(seq_next_element!(seq, Attribute, "UTCTime")),
                     #[cfg(feature = "pkcs7")]
                     oids::SPC_SP_OPUS_INFO_OBJID => {
                         AttributeValues::SpcSpOpusInfo(seq_next_element!(seq, Attribute, "an SpcSpOpusInfo object"))

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -177,6 +177,7 @@ define_oid! {
     SHAKE256 => shake256 => "2.16.840.1.101.3.4.2.12",
 
     // authenticode
+    SIGNING_TIME => signing_time => "1.2.840.113549.1.9.5",
     COUNTER_SIGN => counter_sign => "1.2.840.113549.1.9.6",
     SPC_INDIRECT_DATA_OBJID => spc_indirect_data_objid => "1.3.6.1.4.1.311.2.1.4",
     SPC_STATEMENT_TYPE => spc_statement_type => "1.3.6.1.4.1.311.2.1.11",

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -183,6 +183,7 @@ define_oid! {
     SPC_SP_OPUS_INFO_OBJID => spc_sp_opus_info_objid => "1.3.6.1.4.1.311.2.1.12",
     SPC_PE_IMAGE_DATAOBJ => spc_pe_image_dataobj => "1.3.6.1.4.1.311.2.1.15",
     SPC_SIPINFO_OBJID => spc_sip_info_objid => "1.3.6.1.4.1.311.2.1.30",
+    TIMESTAMP_REQUEST => timestamp_request => "1.3.6.1.4.1.311.3.2.1",
     MS_COUNTER_SIGN => ms_counter_signature => "1.3.6.1.4.1.311.3.3.1",
 
     // CTL

--- a/picky-asn1-x509/src/pkcs7.rs
+++ b/picky-asn1-x509/src/pkcs7.rs
@@ -5,6 +5,7 @@ pub mod crls;
 pub mod ctl;
 pub mod signed_data;
 pub mod signer_info;
+pub mod timestamp;
 
 use crate::oids;
 use signed_data::SignedData;

--- a/picky-asn1-x509/src/pkcs7/content_info.rs
+++ b/picky-asn1-x509/src/pkcs7/content_info.rs
@@ -5,7 +5,7 @@ use widestring::U16String;
 
 use picky_asn1::bit_string::BitString;
 use picky_asn1::restricted_string::{BMPString, CharSetError};
-use picky_asn1::tag::{Encoding, Tag, TagClass, TagPeeker};
+use picky_asn1::tag::{TagClass, TagPeeker};
 use picky_asn1::wrapper::{
     BMPStringAsn1, BitStringAsn1, ExplicitContextTag0, ExplicitContextTag1, ExplicitContextTag2, IA5StringAsn1,
     ImplicitContextTag0, ImplicitContextTag1, IntegerAsn1, ObjectIdentifierAsn1, OctetStringAsn1, Optional,
@@ -104,8 +104,7 @@ impl<'de> de::Deserialize<'de> for EncapsulatedContentInfo {
                     ),
                     oids::PKCS7 => seq
                         .next_element::<ExplicitContextTag0<OctetStringAsn1>>()?
-                        .map(|value| Some(ExplicitContextTag0(ContentValue::Data(value.0))))
-                        .unwrap_or(None),
+                        .map(|value| ExplicitContextTag0(ContentValue::Data(value.0))),
                     #[cfg(feature = "ctl")]
                     oids::CERT_TRUST_LIST => Some(
                         ContentValue::CertificateTrustList(

--- a/picky-asn1-x509/src/pkcs7/timestamp.rs
+++ b/picky-asn1-x509/src/pkcs7/timestamp.rs
@@ -1,0 +1,42 @@
+use crate::pkcs7::content_info::EncapsulatedContentInfo;
+use picky_asn1::wrapper::ObjectIdentifierAsn1;
+use serde::{Deserialize, Serialize};
+
+/// ``` not_rust
+/// [Time Stamping Authenticode Signatures](https://docs.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures)
+/// TimeStampRequest ::= SEQUENCE {
+///     countersignatureType OBJECT IDENTIFIER,
+///     attributes Attributes OPTIONAL,
+///     content  ContentInfo
+/// }
+/// ```
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct TimestampRequest {
+    pub countersignature_type: ObjectIdentifierAsn1,
+    // MSDN: No attributes are currently included in the time stamp request.
+    // attributes
+    pub content: EncapsulatedContentInfo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_timestamp_request() {
+        let decoded = base64::decode(
+            "MIIBIwYKKwYBBAGCNwMCATCCARMGCSqGSIb3DQEHAaCCAQQEggEAQrCUqwV+9+Fl\
+                  bgfJUwua28rmolLOZf/d3alzHUu6P1iV/9crZeu9ShrFdmQ4ZVWTpcR7bcVGPVsW\
+                  QdUgx2n1mJCPied8YPjzC0wfJPvzZzOz9X919EAFRUi4VPs5qEsHJV57YP5mJ2UC\
+                  XqXKSR9HhRO/06TSGz7hkFh+vpsKYVvIZpDXNJPRUilgEDQXjHCdMZyOzPb9wO8k\
+                  cFHbUYZT9lVp9p8Wg+P56RdOANgtS5GKfku2BTsgbwxh5k8GzMnsiaf++O8LgMaE\
+                  zsvEwbfbi+Egxi+7An0T7EttZcn6vbS28vtGKXOg6uzaiBN2u2KYq7f3KTq32sgD\
+                  QgPEuhsAhQ==",
+        )
+        .unwrap();
+
+        let timestamp_request: TimestampRequest = picky_asn1_der::from_bytes(&decoded).unwrap();
+        check_serde!(timestamp_request: TimestampRequest in decoded);
+    }
+}

--- a/picky-server/CHANGELOG.md
+++ b/picky-server/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added 
-- Authenticode timestamping option(behind `/timestamp` REST endpoint).
+### Added
+
+- Authenticode timestamping option (behind `/timestamp` REST endpoint)
 
 ### Changed
 

--- a/picky-server/CHANGELOG.md
+++ b/picky-server/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+- Authenticode timestamping option(behind `/timestamp` REST endpoint).
+
 ### Changed
 
 ## [4.8.0] 2020-11-20

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
-picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "chrono_conversion"], path = "../picky" }
+picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "chrono_conversion", "pkcs7" ], path = "../picky" }
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 mongodm = { version = "0.6", features = ["tokio-runtime"] }
 clap = { features = ["yaml"], version = "2.32" }

--- a/picky-server/src/db/file.rs
+++ b/picky-server/src/db/file.rs
@@ -5,7 +5,7 @@ use crate::db::{CertificateEntry, PickyStorage, StorageError, SCHEMA_LAST_VERSIO
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use std::fs::File;
-use std::io::{Read, Write, self, ErrorKind};
+use std::io::{self, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -81,12 +81,9 @@ where
 
     async fn get(&self, key: &str, buf: &mut [u8]) -> Result<(), FileStorageError> {
         let file_to_open = self.folder_path.join(key);
-        let mut file = File::open(file_to_open.as_path()).map_err(
-            FileStorageError::Io
-        )?;
+        let mut file = File::open(file_to_open.as_path()).map_err(FileStorageError::Io)?;
 
-        file.read_exact(buf)
-            .map_err(FileStorageError::Io)
+        file.read_exact(buf).map_err(FileStorageError::Io)
     }
 }
 
@@ -279,7 +276,7 @@ impl PickyStorage for FileStorage {
             if let Err(err) = self.issued_timestamps_counter.get(&name, &mut content).await {
                 if let FileStorageError::Io(io_error) = &err {
                     if io_error.kind() != ErrorKind::NotFound {
-                        return Err(err.into())
+                        return Err(err.into());
                     }
                 }
             }

--- a/picky-server/src/db/file.rs
+++ b/picky-server/src/db/file.rs
@@ -252,7 +252,7 @@ impl PickyStorage for FileStorage {
     }
 
     fn get_addressing_hash_by_name(&self, name: &str) -> BoxFuture<'_, Result<String, StorageError>> {
-        let name = format!("{}{}", name, TXT_EXT);
+        let name = format!("{}{}", name, TXT_EXT).replace(" ", "_");
         async move {
             let file = self
                 .name
@@ -274,7 +274,7 @@ impl PickyStorage for FileStorage {
     }
 
     fn increase_issued_authenticode_timestamps_counter(&self) -> BoxFuture<'_, Result<(), StorageError>> {
-        let name = format!("{}{}", "timestamp_counter_store", TXT_EXT).replace(" ", "_");
+        let name = format!("{}{}", "timestamp_counter_store", TXT_EXT);
 
         async move {
             let mut content = [0; 4];

--- a/picky-server/src/db/file.rs
+++ b/picky-server/src/db/file.rs
@@ -77,7 +77,7 @@ where
         Ok(())
     }
 
-    async fn get(&self, key: &str, buf: &mut Vec<u8>) -> Result<(), FileStorageError> {
+    async fn get(&self, key: &str, buf: &mut [u8]) -> Result<(), FileStorageError> {
         let mut file = File::open(self.folder_path.join(key)).map_err(|e| {
             format!(
                 "File doesn't exists ({}{}): {}",
@@ -252,7 +252,7 @@ impl PickyStorage for FileStorage {
     }
 
     fn get_addressing_hash_by_name(&self, name: &str) -> BoxFuture<'_, Result<String, StorageError>> {
-        let name = format!("{}{}", name, TXT_EXT).replace(" ", "_");
+        let name = format!("{}{}", name, TXT_EXT);
         async move {
             let file = self
                 .name
@@ -277,7 +277,7 @@ impl PickyStorage for FileStorage {
         let name = format!("{}{}", "timestamp_counter_store", TXT_EXT).replace(" ", "_");
 
         async move {
-            let mut content = 0_u32.to_le_bytes().to_vec();
+            let mut content = [0; 4];
             if let Err(err) = self.issued_timestamps_counter.get(&name, &mut content).await {
                 if !err.to_string().contains("File doesn't exists") {
                     return Err(err.into());

--- a/picky-server/src/db/mod.rs
+++ b/picky-server/src/db/mod.rs
@@ -70,6 +70,7 @@ pub trait PickyStorage: Send + Sync {
     fn get_cert_by_addressing_hash<'a>(&'a self, hash: &'a str) -> BoxFuture<'a, Result<Vec<u8>, StorageError>>;
     fn get_key_by_addressing_hash<'a>(&'a self, hash: &'a str) -> BoxFuture<'a, Result<Vec<u8>, StorageError>>;
     fn get_addressing_hash_by_name<'a>(&'a self, name: &'a str) -> BoxFuture<'a, Result<String, StorageError>>;
+    fn increase_issued_authenticode_timestamps_counter(&self) -> BoxFuture<'_, Result<(), StorageError>>;
     fn get_addressing_hash_by_key_identifier<'a>(
         &'a self,
         key_identifier: &'a str,

--- a/picky-server/src/db/mongodb/model.rs
+++ b/picky-server/src/db/mongodb/model.rs
@@ -154,7 +154,7 @@ impl mongodm::CollectionConfig for TimestampCollConf {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IssuedTimestampsCounter {
-    pub counter: u32,
+    pub counter: i64,
 }
 
 impl mongodm::Model for IssuedTimestampsCounter {

--- a/picky-server/src/db/mongodb/model.rs
+++ b/picky-server/src/db/mongodb/model.rs
@@ -143,3 +143,20 @@ pub struct HashLookupEntry {
 impl mongodm::Model for HashLookupEntry {
     type CollConf = HashCollConf;
 }
+
+pub struct TimestampCollConf;
+
+impl mongodm::CollectionConfig for TimestampCollConf {
+    fn collection_name() -> &'static str {
+        "timestamps_counter"
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IssuedTimestampsCounter {
+    pub counter: u32,
+}
+
+impl mongodm::Model for IssuedTimestampsCounter {
+    type CollConf = TimestampCollConf;
+}

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -278,7 +278,7 @@ impl ServerController {
             .internal_error()?;
 
         let digest = timestamp_request.digest();
-        let picky_server_hash = config.signing_algorithm.inner_hash_algo();
+        let picky_server_hash = config.signing_algorithm.hash_algorithm();
 
         let attributes = vec![
             Attribute::new_content_type_pkcs7(),

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -8,7 +8,13 @@ use crate::picky_controller::Picky;
 use crate::utils::{GreedyError, PathOr};
 use log4rs::Handle;
 use picky::pem::{parse_pem, to_pem, Pem};
+use picky::x509::date::UTCDate;
+use picky::x509::pkcs7::{
+    authenticode::{Attribute, AuthenticodeSignatureBuilder},
+    timestamp::TimestampRequest,
+};
 use picky::x509::{Cert, Csr};
+use saphir::hyper::body::Buf;
 use saphir::prelude::*;
 use saphir::response::Builder as ResponseBuilder;
 use serde_json::{self, Value};
@@ -228,6 +234,74 @@ impl ServerController {
                 ("Couldn't reload config... See logs", StatusCode::INTERNAL_SERVER_ERROR)
             }
         }
+    }
+
+    #[post("/timestamp")]
+    async fn authenticode_timestamp(&self, req: Request) -> Result<ResponseBuilder, StatusCode> {
+        let req = req.load_body().await.bad_request()?;
+        let timestamp_request = TimestampRequest::from_der(req.body().bytes()).bad_request()?;
+
+        let config = self.read_conf().await;
+
+        let intermediate_name = format!("{} Authority", config.realm);
+        let intermediate_hash = self
+            .storage
+            .get_addressing_hash_by_name(&intermediate_name)
+            .await
+            .map_err(|e| format!("couldn't fetch intermediate cert: {}", e))
+            .internal_error()?;
+
+        let intermediate_cert_der = self
+            .storage
+            .get_cert_by_addressing_hash(&intermediate_hash)
+            .await
+            .map_err(|e| format!("couldn't get intermediate cert der: {}", e))
+            .internal_error()?;
+
+        let intermediate_cert = Cert::from_der(&intermediate_cert_der)
+            .map_err(|e| format!("couldn't deserialize intermediate cert: {}", e))
+            .internal_error()?;
+
+        let intermediate_pk_der = self
+            .storage
+            .get_key_by_addressing_hash(&intermediate_hash)
+            .await
+            .map_err(|e| format!("couldn't fetch intermediate private key: {}", e))
+            .internal_error()?;
+
+        let intermediate_pk = Picky::parse_pk_from_magic_der(&intermediate_pk_der)
+            .map_err(|e| e.to_string())
+            .internal_error()?;
+
+        let digest = timestamp_request.digest();
+
+        let attributes = vec![
+            Attribute::new_content_type_pkcs7(),
+            Attribute::new_signing_time(UTCDate::now().into()),
+            Attribute::new_message_digest(digest.to_owned()),
+        ];
+
+        let authenticode_signature = AuthenticodeSignatureBuilder::new()
+            .digest_algorithm(config.signing_algorithm.inner_hash_algo())
+            .signing_key(&intermediate_pk)
+            .content_info(timestamp_request.content().clone())
+            .authenticated_attributes(attributes)
+            .issuer_and_serial_number(
+                intermediate_cert.issuer_name(),
+                intermediate_cert.serial_number().0.clone(),
+            )
+            .certs(vec![intermediate_cert])
+            .build()
+            .internal_error()?;
+
+        let raw_signature = authenticode_signature.to_der().internal_error()?;
+
+        let response = ResponseBuilder::new()
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .body(raw_signature)
+            .status(StatusCode::OK);
+
+        Ok(response)
     }
 }
 

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -289,7 +289,7 @@ impl ServerController {
         let authenticode_signature = AuthenticodeSignatureBuilder::new()
             .digest_algorithm(picky_server_hash)
             .signing_key(&intermediate_pk)
-            .content_info(timestamp_request.content().clone())
+            .content_info(timestamp_request.into_content())
             .authenticated_attributes(attributes)
             .issuer_and_serial_number(
                 intermediate_cert.issuer_name(),

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -239,7 +239,7 @@ impl ServerController {
 
         let mut body = req.body().to_vec();
         body.retain(|&x| x != b'\n' && x != b'\r' && x != b'\0'); // Removing CRLF entries
-        
+
         let der = base64::decode(body)
             .map_err(|e| format!("base64 failed to decode timestamp request body: {}", e))
             .internal_error()?;

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -238,7 +238,7 @@ impl ServerController {
         let req = req.load_body().await.bad_request()?;
 
         let mut body = req.body().to_vec();
-        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // do not include CRL
+        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // Removing CRLF entries
 
         let der = base64::decode(body)
             .map_err(|e| format!("base64 failed to decode timestamp request body: {}", e))

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -238,8 +238,8 @@ impl ServerController {
         let req = req.load_body().await.bad_request()?;
 
         let mut body = req.body().to_vec();
-        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // Removing CRLF entries
-
+        body.retain(|&x| x != b'\n' && x != b'\r' && x != b'\0'); // Removing CRLF entries
+        
         let der = base64::decode(body)
             .map_err(|e| format!("base64 failed to decode timestamp request body: {}", e))
             .internal_error()?;

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -298,7 +298,7 @@ impl ServerController {
 
         let response = ResponseBuilder::new()
             .header(header::CONTENT_TYPE, "application/octet-stream")
-            .body(raw_signature)
+            .body(base64::encode(raw_signature))
             .status(StatusCode::OK);
 
         Ok(response)

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -238,8 +238,8 @@ impl ServerController {
         let req = req.load_body().await.bad_request()?;
 
         let mut body = req.body().to_vec();
-        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // do not include CRLF!
-                                                               //println!("{:02X?}", &body[390..397]);
+        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // do not include CRL
+
         let der = base64::decode(body)
             .map_err(|e| format!("base64 failed to decode timestamp request body: {}", e))
             .internal_error()?;

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -16,4 +16,4 @@ lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "8f439c" }
 [dependencies.picky]
 path = "../picky"
 default-features = false
-features = ["wincert", "ctl"]
+features = ["wincert", "ctl", "ctl_http_fetch", "http_timestamp"]

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2.33"
 walkdir = "2.3"
 base64 = "0.13"
 encoding = "0.2"
-lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "797f33" }
+lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "8f439c" }
 
 [dependencies.picky]
 path = "../picky"

--- a/picky-signtool/src/config.rs
+++ b/picky-signtool/src/config.rs
@@ -139,7 +139,7 @@ pub fn config() -> ArgMatches<'static> {
             .short("t")
             .long(ARG_TIMESTAMP)
             .value_name("URL")
-            .help("Specify url of a Authenticode TSA server to timestamp")
+            .help("Specify url of a Authenticode TSA server when timestamping")
             .takes_value(true)
             .requires(ARG_SIGN)
             .display_order(8)

--- a/picky-signtool/src/config.rs
+++ b/picky-signtool/src/config.rs
@@ -16,6 +16,7 @@ pub const ARG_SIGN: &str = "sign";
 
 pub const ARG_CERTFILE: &str = "certfile";
 pub const ARG_PRIVATE_KEY: &str = "rsa-private-key";
+pub const ARG_TIMESTAMP: &str = "timestamp";
 
 pub const ARG_VERIFY: &str = "verify";
 pub const ARG_VERIFY_BASIC: &str = "basic";
@@ -134,6 +135,15 @@ pub fn config() -> ArgMatches<'static> {
                 .requires_all(&[ARG_SIGN, ARG_CERTFILE])
                 .display_order(7),
         )
+        .arg(Arg::with_name(ARG_TIMESTAMP)
+            .short("t")
+            .long(ARG_TIMESTAMP)
+            .value_name("URL")
+            .help("Specify url of a Authenticode TSA server to timestamp")
+            .takes_value(true)
+            .requires(ARG_SIGN)
+            .display_order(8)
+        )
         .arg(
             Arg::with_name(ARG_VERIFY)
                 .short("v")
@@ -162,7 +172,7 @@ pub fn config() -> ArgMatches<'static> {
                     ARG_VERIFY_CHAIN,
                     ARG_VERIFY_CA,
                 ])
-                .display_order(8),
+                .display_order(9),
         )
         .arg(
             Arg::with_name(ARG_LOGGING)
@@ -180,7 +190,7 @@ pub fn config() -> ArgMatches<'static> {
                     ARG_LOGGING_ERR,
                     ARG_LOGGING_CRITICAL,
                 ])
-                .display_order(9),
+                .display_order(10),
         )
         .get_matches()
 }

--- a/picky-signtool/src/sign.rs
+++ b/picky-signtool/src/sign.rs
@@ -22,7 +22,7 @@ use crate::config::{
 use crate::get_utf8_file_name;
 use crate::verify::extract_signed_ps_file_content;
 use picky::pem::Pem;
-use picky::x509::pkcs7::timestamp::AuthenticodeTimestamper;
+use picky::x509::pkcs7::timestamp::http_timestamp::AuthenticodeTimestamper;
 
 const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 const UTF16_BE_BOM: [u8; 2] = [0xFE, 0xFF];

--- a/picky-signtool/src/sign.rs
+++ b/picky-signtool/src/sign.rs
@@ -10,17 +10,19 @@ use lief::{Binary, LogLevel};
 use picky::hash::HashAlgorithm;
 use picky::key::PrivateKey;
 use picky::x509::pkcs7::authenticode::{AuthenticodeSignature, ShaVariant};
+use picky::x509::pkcs7::timestamp::Timestamper;
 use picky::x509::pkcs7::Pkcs7;
 use picky::x509::wincert::{CertificateType, WinCertificate};
 
 use crate::config::{
     ARG_BINARY, ARG_LOGGING, ARG_LOGGING_CRITICAL, ARG_LOGGING_DEBUG, ARG_LOGGING_ERR, ARG_LOGGING_INFO,
-    ARG_LOGGING_TRACE, ARG_LOGGING_WARN, ARG_OUTPUT, ARG_PS_SCRIPT, CRLF, PS_AUTHENTICODE_FOOTER,
+    ARG_LOGGING_TRACE, ARG_LOGGING_WARN, ARG_OUTPUT, ARG_PS_SCRIPT, ARG_TIMESTAMP, CRLF, PS_AUTHENTICODE_FOOTER,
     PS_AUTHENTICODE_HEADER, PS_AUTHENTICODE_LINES_SPLITTER,
 };
 use crate::get_utf8_file_name;
 use crate::verify::extract_signed_ps_file_content;
 use picky::pem::Pem;
+use picky::x509::pkcs7::timestamp::AuthenticodeTimestamper;
 
 const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 const UTF16_BE_BOM: [u8; 2] = [0xFE, 0xFF];
@@ -47,9 +49,15 @@ pub fn sign(
     let private_key = PrivateKey::from_pem(&private_key).context("Failed to parse RSA Private key")?;
     let pkcs7 = Pkcs7::from_pem(&certfile).context("Failed to parse Pkcs7 certificate")?;
 
+    let timestamper = if let Some(url) = matches.value_of(ARG_TIMESTAMP) {
+        Some(AuthenticodeTimestamper::new(url)?)
+    } else {
+        None
+    };
+
     if matches.is_present(ARG_PS_SCRIPT) {
         for ps_file in files.iter() {
-            sign_script(&pkcs7, &private_key, ps_file.as_path())?;
+            sign_script(&pkcs7, &private_key, ps_file.as_path(), timestamper.as_ref())?;
 
             let file_name = get_utf8_file_name(ps_file.as_path())?;
             println!("Signed {} successfully", file_name);
@@ -88,6 +96,7 @@ pub fn sign(
             file.clone(),
             PathBuf::from(output_path),
             binary_name.to_owned(),
+            timestamper.as_ref(),
         )?;
 
         println!("Signed {} successfully!", binary_name);
@@ -96,7 +105,12 @@ pub fn sign(
     Ok(())
 }
 
-fn sign_script(pkcs7: &Pkcs7, private_key: &PrivateKey, file_path: &Path) -> anyhow::Result<()> {
+fn sign_script(
+    pkcs7: &Pkcs7,
+    private_key: &PrivateKey,
+    file_path: &Path,
+    timestamper: Option<&impl Timestamper>,
+) -> anyhow::Result<()> {
     let mut file = OpenOptions::new()
         .append(true)
         .read(true)
@@ -106,8 +120,15 @@ fn sign_script(pkcs7: &Pkcs7, private_key: &PrivateKey, file_path: &Path) -> any
     let checksum = compute_ps_file_checksum_from_content(file_path, HashAlgorithm::SHA2_256)
         .with_context(|| format!("Failed to compute checksum for {:?}", file))?;
 
-    let authenticode_signature = AuthenticodeSignature::new(pkcs7, checksum, ShaVariant::SHA2_256, private_key, None)
-        .with_context(|| format!("Failed to create authenticode signature for {:?}", file))?
+    let mut authenticode_signature =
+        AuthenticodeSignature::new(pkcs7, checksum, ShaVariant::SHA2_256, private_key, None)
+            .with_context(|| format!("Failed to create authenticode signature for {:?}", file))?;
+
+    if timestamper.is_some() {
+        authenticode_signature.timestamp(timestamper.unwrap(), HashAlgorithm::SHA2_256)?;
+    }
+
+    let raw_authenticode_signature = authenticode_signature
         .to_pem()
         .context("Failed convert to authenticode signature to PEM format")?
         .to_string();
@@ -117,7 +138,7 @@ fn sign_script(pkcs7: &Pkcs7, private_key: &PrivateKey, file_path: &Path) -> any
     ps_authenticode_signature.push_str(PS_AUTHENTICODE_HEADER);
     ps_authenticode_signature.push_str(CRLF);
 
-    for line in authenticode_signature.lines() {
+    for line in raw_authenticode_signature.lines() {
         if line != "-----END PKCS7-----" && line != "-----BEGIN PKCS7-----" {
             ps_authenticode_signature.push_str(PS_AUTHENTICODE_LINES_SPLITTER);
             ps_authenticode_signature.push_str(line);
@@ -137,6 +158,7 @@ fn sign_binary(
     binary_path: PathBuf,
     output_path: PathBuf,
     binary_name: String,
+    timestamper: Option<&impl Timestamper>,
 ) -> anyhow::Result<()> {
     let binary = Binary::new(binary_path).map_err(|err| anyhow!("Failed to load the executable: {}", err))?;
 
@@ -144,15 +166,22 @@ fn sign_binary(
         .get_file_hash_sha256()
         .map_err(|err| anyhow!("Failed to compute file hash: {}", err))?;
 
-    let authenticode_signature =
+    let mut authenticode_signature =
         AuthenticodeSignature::new(pkcs7, file_hash, ShaVariant::SHA2_256, private_key, Some(binary_name))
-            .context("Failed to create authenticode signature for")?
-            .to_der()
-            .context("Failed to convert authenticode signature to der")?;
+            .context("Failed to create authenticode signature for")?;
 
-    let wincert = WinCertificate::from_certificate(authenticode_signature, CertificateType::WinCertTypePkcsSignedData)
-        .encode()
-        .map_err(|err| anyhow!("Failed to wrap authenticode signature in WinCertificate: {}", err))?;
+    if timestamper.is_some() {
+        authenticode_signature.timestamp(timestamper.unwrap(), HashAlgorithm::SHA2_256)?;
+    }
+
+    let raw_authenticode_signature = authenticode_signature
+        .to_der()
+        .context("Failed to convert authenticode signature to der")?;
+
+    let wincert =
+        WinCertificate::from_certificate(raw_authenticode_signature, CertificateType::WinCertTypePkcsSignedData)
+            .encode()
+            .map_err(|err| anyhow!("Failed to wrap authenticode signature in WinCertificate: {}", err))?;
 
     binary
         .set_authenticode_data(wincert)

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -11,8 +11,9 @@ use lief::Binary;
 use picky::hash::HashAlgorithm;
 use picky::x509::date::UTCDate;
 use picky::x509::pkcs7::authenticode::{AuthenticodeSignature, AuthenticodeValidator, ShaVariant};
+use picky::x509::pkcs7::ctl::http_fetch::CtlHttpFetch;
+use picky::x509::pkcs7::ctl::CertificateTrustList;
 use picky::x509::wincert::WinCertificate;
-use picky::x509::pkcs7::ctl::{CertificateTrustList, http_fetch::CtlHttpFetch};
 
 use crate::config::{
     ARG_BINARY, ARG_PS_SCRIPT, ARG_VERIFY, ARG_VERIFY_BASIC, ARG_VERIFY_CA, ARG_VERIFY_CHAIN,
@@ -198,7 +199,7 @@ fn apply_flags<'a>(
     flags: &[String],
     time: &'a UTCDate,
     file_hash: Vec<u8>,
-    ctl: Option<&'a CertificateTrustList>
+    ctl: Option<&'a CertificateTrustList>,
 ) -> &'a AuthenticodeValidator<'a> {
     let validator = validator
         .ignore_basic_authenticode_validation()

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -12,6 +12,7 @@ use picky::hash::HashAlgorithm;
 use picky::x509::date::UTCDate;
 use picky::x509::pkcs7::authenticode::{AuthenticodeSignature, AuthenticodeValidator, ShaVariant};
 use picky::x509::wincert::WinCertificate;
+use picky::x509::pkcs7::ctl::{CertificateTrustList, http_fetch::CtlHttpFetch};
 
 use crate::config::{
     ARG_BINARY, ARG_PS_SCRIPT, ARG_VERIFY, ARG_VERIFY_BASIC, ARG_VERIFY_CA, ARG_VERIFY_CHAIN,
@@ -101,11 +102,18 @@ pub fn verify(matches: &ArgMatches, files: &[PathBuf]) -> anyhow::Result<()> {
         .cloned()
         .collect::<Vec<String>>();
 
+    let ctl = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CHAIN) {
+        let ctl = CertificateTrustList::fetch()?;
+        Some(ctl)
+    } else {
+        None
+    };
+
     for (authenticode_signature, file_name, file_hash) in authenticode_signatures {
         let validator = authenticode_signature.authenticode_verifier();
 
         let now = UTCDate::now();
-        let validator = apply_flags(&validator, &flags, &now, file_hash);
+        let validator = apply_flags(&validator, &flags, &now, file_hash, ctl.as_ref());
 
         match validator.verify() {
             Ok(()) => println!("{} has valid digital signature", file_name),
@@ -190,6 +198,7 @@ fn apply_flags<'a>(
     flags: &[String],
     time: &'a UTCDate,
     file_hash: Vec<u8>,
+    ctl: Option<&'a CertificateTrustList>
 ) -> &'a AuthenticodeValidator<'a> {
     let validator = validator
         .ignore_basic_authenticode_validation()
@@ -218,7 +227,12 @@ fn apply_flags<'a>(
     };
 
     let validator = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CHAIN) {
-        validator.require_chain_check()
+        let validator = validator.require_chain_check();
+        if let Some(ctl) = ctl {
+            validator.ctl(ctl)
+        } else {
+            validator
+        }
     } else {
         &validator
     };

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -33,13 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl From<Pkcs7> for AuthenticodeSignature`
 - `From<AuthenticodeSignature> for Pkcs7`
 - Authenticode validation
-- Add possibility to timestamp `AuthenticodeSignature`: 
-  - Add method `timestamp` to `AuthenticodeSignature`.
-  - Add `Timestamper` trait.
-  - Timestamping over HTTP is behind `http_timestamp` feature.
+- Support for `AuthenticodeSignature` timestamping:
+  - Method `timestamp` to `AuthenticodeSignature`
+  - `Timestamper` trait.
+  - Timestamping implementation using reqwest is behind `http_timestamp` feature
 - Add  Authenticode timestamp request struct - `TimestampRequest`
-- Add `AuthenticodeBuilder` for easier creating `AuthenticodeSignature` without usage low-level API.
-- Add `SignatureAlgorithm::hash_algorithm` 
+- Add `AuthenticodeBuilder` for easier `AuthenticodeSignature` creation
+- Add `SignatureAlgorithm::hash_algorithm`
 
 ### Changed
 

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for MD5 hashing
 - CTL implementation behind `ctl` feature
+- CTL fetching over HTTP is behind `ctl_http_fetch` feature
 - `Pkcs7::digest_algorithms`
 - `Pkcs7::signer_infos`
 - `Pkcs7::encapsulated_content_info`
@@ -32,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl From<Pkcs7> for AuthenticodeSignature`
 - `From<AuthenticodeSignature> for Pkcs7`
 - Authenticode validation
+- Add possibility to timestamp `AuthenticodeSignature`: 
+  - Add method `timestamp` to `AuthenticodeSignature`.
+  - Add `Timestamper` trait.
+  - Timestamping over HTTP is behind `http_timestamp` feature.
+- Add  Authenticode timestamp request struct - `TimestampRequest`
+- Add `AuthenticodeBuilder` for easier creating `AuthenticodeSignature` without usage low-level API.
+- Add `SignatureAlgorithm::hash_algorithm` 
 
 ### Changed
 

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -60,8 +60,10 @@ jose = ["serde_json", "aes-gcm"]
 http_signature = []
 
 # secondary features
-pkcs7 = ["x509", "picky-asn1-x509/pkcs7", "reqwest"]
-ctl = ["picky-asn1-x509/ctl", "pkcs7", "chrono_conversion", "cab"]
+pkcs7 = ["x509", "picky-asn1-x509/pkcs7"]
+http_timestamp = ["reqwest"]
+ctl = ["picky-asn1-x509/ctl", "pkcs7", "chrono_conversion"]
+ctl_http_fetch = ["reqwest", "cab"]
 wincert = ["byteorder"]
 http_trait_impl = ["http"]
 chrono_conversion = ["chrono", "picky-asn1/chrono_conversion"]

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -60,8 +60,8 @@ jose = ["serde_json", "aes-gcm"]
 http_signature = []
 
 # secondary features
-pkcs7 = ["x509", "picky-asn1-x509/pkcs7"]
-ctl = ["picky-asn1-x509/ctl", "pkcs7", "chrono_conversion", "reqwest", "cab"]
+pkcs7 = ["x509", "picky-asn1-x509/pkcs7", "reqwest"]
+ctl = ["picky-asn1-x509/ctl", "pkcs7", "chrono_conversion", "cab"]
 wincert = ["byteorder"]
 http_trait_impl = ["http"]
 chrono_conversion = ["chrono", "picky-asn1/chrono_conversion"]

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -127,7 +127,7 @@ impl SignatureAlgorithm {
 
         Ok(())
     }
-    
+
     pub fn hash_algorithm(&self) -> HashAlgorithm {
         match &self {
             SignatureAlgorithm::RsaPkcs1v15(hash_algo) => *hash_algo,

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -127,4 +127,10 @@ impl SignatureAlgorithm {
 
         Ok(())
     }
+
+    pub fn inner_hash_algo(&self) -> HashAlgorithm {
+        match &self {
+            SignatureAlgorithm::RsaPkcs1v15(hash_algo) => *hash_algo,
+        }
+    }
 }

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -127,8 +127,8 @@ impl SignatureAlgorithm {
 
         Ok(())
     }
-
-    pub fn inner_hash_algo(&self) -> HashAlgorithm {
+    
+    pub fn hash_algorithm(&self) -> HashAlgorithm {
         match &self {
             SignatureAlgorithm::RsaPkcs1v15(hash_algo) => *hash_algo,
         }

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -824,7 +824,11 @@ impl<'a> AuthenticodeValidator<'a> {
 
     // https://github.com/robstradling/authroot_parser was used as a reference while implementing this function
     #[cfg(feature = "ctl")]
-    fn h_verify_ca_certificate_against_ctl(&self, ctl: &CertificateTrustList, ca_name: &DirectoryName) -> AuthenticodeResult<()> {
+    fn h_verify_ca_certificate_against_ctl(
+        &self,
+        ctl: &CertificateTrustList,
+        ca_name: &DirectoryName,
+    ) -> AuthenticodeResult<()> {
         use chrono::{DateTime, Duration, NaiveDate, Utc};
         use picky_asn1::wrapper::OctetStringAsn1;
         use std::ops::Add;
@@ -1645,7 +1649,6 @@ mod test {
             Some("self_signed_authenticode_signature_validation_against_ctl_with_excluded_ca_certificate".to_string()),
         )
         .unwrap();
-
 
         let validator = authenticode_signature.authenticode_verifier();
         let ca_name = authenticode_signature

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -1152,16 +1152,13 @@ impl<'a> AuthenticodeSignatureBuilder<'a> {
 
         // certificates contains the signer certificate and any intermediate certificates,
         // but typically does not contain the root certificate
-        let certificates = certificates
-            .into_iter()
-            .filter_map(|cert| {
-                if cert.ty() != CertType::Root {
-                    Some(Certificate::from(cert))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<Certificate>>();
+        let certificates = certificates.into_iter().filter_map(|cert| {
+            if cert.ty() != CertType::Root {
+                Some(Certificate::from(cert))
+            } else {
+                None
+            }
+        });
 
         let digest_encryption_algorithm = AlgorithmIdentifier::new_rsa_encryption_with_sha(digest_algorithm)
             .map_err(AuthenticodeError::UnsupportedAlgorithmError)?;
@@ -1203,7 +1200,7 @@ impl<'a> AuthenticodeSignatureBuilder<'a> {
         };
 
         let mut certs = Vec::new();
-        for cert in certificates.into_iter() {
+        for cert in certificates {
             let raw_certificates = picky_asn1_der::to_vec(&cert)?;
             certs.push(CertificateChoices::Certificate(picky_asn1_der::from_bytes(
                 &raw_certificates,

--- a/picky/src/x509/pkcs7/ctl.rs
+++ b/picky/src/x509/pkcs7/ctl.rs
@@ -1,9 +1,9 @@
+use crate::x509::pkcs7::{Pkcs7, Pkcs7Error};
 use picky_asn1_x509::content_info::ContentValue;
 use picky_asn1_x509::pkcs7::ctl::CTLEntry;
-use crate::x509::pkcs7::{Pkcs7, Pkcs7Error};
+pub use picky_asn1_x509::pkcs7::ctl::CTLEntryAttributeValues;
 use std::io;
 use thiserror::Error;
-pub use picky_asn1_x509::pkcs7::ctl::CTLEntryAttributeValues;
 
 #[derive(Debug, Error)]
 pub enum CtlError {
@@ -44,12 +44,10 @@ impl CertificateTrustList {
     }
 }
 
-
-
 #[cfg(feature = "ctl_http_fetch")]
 pub mod http_fetch {
-    use std::io::{Cursor, Read};
     use super::*;
+    use std::io::{Cursor, Read};
 
     pub trait CtlHttpFetch {
         fn fetch() -> Result<CertificateTrustList, CtlError>;
@@ -95,9 +93,9 @@ pub mod http_fetch {
 
 #[cfg(test)]
 mod tests {
+    use super::http_fetch::CtlHttpFetch;
     use super::*;
     use crate::x509::pkcs7::Pkcs7;
-    use super::http_fetch::CtlHttpFetch;
 
     #[test]
     fn parse_certificate_trust_list_in_der() {

--- a/picky/src/x509/pkcs7/ctl.rs
+++ b/picky/src/x509/pkcs7/ctl.rs
@@ -1,10 +1,8 @@
 use picky_asn1_x509::content_info::ContentValue;
 use picky_asn1_x509::pkcs7::ctl::CTLEntry;
-use std::io::{self, Cursor, Read};
-
 use crate::x509::pkcs7::{Pkcs7, Pkcs7Error};
+use std::io;
 use thiserror::Error;
-
 pub use picky_asn1_x509::pkcs7::ctl::CTLEntryAttributeValues;
 
 #[derive(Debug, Error)]
@@ -21,46 +19,12 @@ pub enum CtlError {
     IncorrectContentValue,
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct CertificateTrustList {
     pkcs7: Pkcs7,
 }
 
 impl CertificateTrustList {
-    pub fn fetch() -> Result<Self, CtlError> {
-        let ctl_url: &str =
-            "http://www.download.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab";
-
-        let mut cab = reqwest::blocking::get(ctl_url).map_err(|err| CtlError::DownloadError {
-            description: err.to_string(),
-        })?;
-
-        if !cab.status().is_success() {
-            return Err(CtlError::DownloadError {
-                description: format!("Response status code is {}", cab.status()),
-            });
-        }
-
-        let mut buffer = Vec::new();
-        cab.copy_to(&mut buffer).map_err(|err| CtlError::ExtractingError {
-            description: format!("Failed to copy Response body to Vec: {}", err),
-        })?;
-
-        let mut cabinet = cab::Cabinet::new(Cursor::new(&mut buffer)).map_err(|err| CtlError::ExtractingError {
-            description: format!("Failed to parse Cabinet file: {}", err),
-        })?;
-
-        let mut authroot = cabinet
-            .read_file("authroot.stl")
-            .expect("authroot.stl should be present in authrootstl.cab");
-
-        let mut ctl_buffer = Vec::new();
-        authroot.read_to_end(&mut ctl_buffer)?;
-
-        let pkcs7: Pkcs7 = Pkcs7::from_der(&ctl_buffer).map_err(CtlError::FailedToParseCtl)?;
-
-        Ok(Self { pkcs7 })
-    }
-
     pub fn ctl_entries(&self) -> Result<&[CTLEntry], CtlError> {
         let content_value = self
             .pkcs7
@@ -80,10 +44,60 @@ impl CertificateTrustList {
     }
 }
 
+
+
+#[cfg(feature = "ctl_http_fetch")]
+pub mod http_fetch {
+    use std::io::{Cursor, Read};
+    use super::*;
+
+    pub trait CtlHttpFetch {
+        fn fetch() -> Result<CertificateTrustList, CtlError>;
+    }
+
+    impl CtlHttpFetch for CertificateTrustList {
+        fn fetch() -> Result<CertificateTrustList, CtlError> {
+            let ctl_url: &str =
+                "http://www.download.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab";
+
+            let mut cab = reqwest::blocking::get(ctl_url).map_err(|err| CtlError::DownloadError {
+                description: err.to_string(),
+            })?;
+
+            if !cab.status().is_success() {
+                return Err(CtlError::DownloadError {
+                    description: format!("Response status code is {}", cab.status()),
+                });
+            }
+
+            let mut buffer = Vec::new();
+            cab.copy_to(&mut buffer).map_err(|err| CtlError::ExtractingError {
+                description: format!("Failed to copy Response body to Vec: {}", err),
+            })?;
+
+            let mut cabinet = cab::Cabinet::new(Cursor::new(&mut buffer)).map_err(|err| CtlError::ExtractingError {
+                description: format!("Failed to parse Cabinet file: {}", err),
+            })?;
+
+            let mut authroot = cabinet
+                .read_file("authroot.stl")
+                .expect("authroot.stl should be present in authrootstl.cab");
+
+            let mut ctl_buffer = Vec::new();
+            authroot.read_to_end(&mut ctl_buffer)?;
+
+            let pkcs7: Pkcs7 = Pkcs7::from_der(&ctl_buffer).map_err(CtlError::FailedToParseCtl)?;
+
+            Ok(CertificateTrustList { pkcs7 })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::x509::pkcs7::Pkcs7;
+    use super::http_fetch::CtlHttpFetch;
 
     #[test]
     fn parse_certificate_trust_list_in_der() {

--- a/picky/src/x509/pkcs7/mod.rs
+++ b/picky/src/x509/pkcs7/mod.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 pub mod authenticode;
 #[cfg(feature = "ctl")]
 pub mod ctl;
+pub mod timestamp;
 
 type Pkcs7Result<T> = Result<T, Pkcs7Error>;
 

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -79,7 +79,7 @@ impl Timestamper for AuthenticodeTimestamper {
             .map_err(TimestampError::RemoteServerResponseError)?
             .to_vec();
 
-        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // Removing CRLF entries
+        body.retain(|&x| x != b'\n' && x != b'\r' && x != b'\0'); // Removing CRLF entries
 
         let der = base64::decode(body).map_err(|_| TimestampError::Base64DecodeError)?;
         let token = Pkcs7::from_der(&der).map_err(TimestampError::Pkcs7Error)?;

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -55,7 +55,7 @@ impl Timestamper for AuthenticodeTimestamper {
         let timestamp_request = TimestampRequest::new(digest);
 
         let client = Client::new();
-        let content = timestamp_request.to_der()?;
+        let content = base64::encode(timestamp_request.to_der()?);
 
         let request = client
             .request(Method::POST, self.url.clone())
@@ -79,7 +79,7 @@ impl Timestamper for AuthenticodeTimestamper {
             .map_err(TimestampError::RemoteServerResponseError)?
             .to_vec();
 
-        body.retain(|&x| x != 0x0d && x != 0x0a); // do not include CRLF!
+        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // do not include CRLF!
 
         let der = base64::decode(body).map_err(|_| TimestampError::Base64DecodeError)?;
         let token = Pkcs7::from_der(&der).map_err(TimestampError::Pkcs7Error)?;

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -79,7 +79,7 @@ impl Timestamper for AuthenticodeTimestamper {
             .map_err(TimestampError::RemoteServerResponseError)?
             .to_vec();
 
-        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // do not include CRLF!
+        body.retain(|&x| x != 0x0d && x != 0x0a && x != 0x00); // Removing CRLF entries
 
         let der = base64::decode(body).map_err(|_| TimestampError::Base64DecodeError)?;
         let token = Pkcs7::from_der(&der).map_err(TimestampError::Pkcs7Error)?;

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -1,0 +1,114 @@
+use crate::hash::HashAlgorithm;
+use crate::x509::pkcs7::Pkcs7;
+use picky_asn1_der::Asn1DerError;
+use picky_asn1_x509::pkcs7::content_info::{ContentValue, EncapsulatedContentInfo};
+use picky_asn1_x509::pkcs7::signed_data::SignedData;
+use picky_asn1_x509::pkcs7::signer_info::UnsignedAttribute;
+use picky_asn1_x509::signer_info::UnsignedAttributeValue;
+use picky_asn1_x509::timestamp::TimestampRequest;
+use picky_asn1_x509::{oids, Pkcs7Certificate};
+use reqwest::blocking::Client;
+use reqwest::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::{Method, StatusCode, Url};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TimestampError {
+    #[error(transparent)]
+    Asn1DerError(#[from] Asn1DerError),
+    #[error("Remote Authenticode TSA server response with {0} status code")]
+    BadResponse(StatusCode),
+    #[error("Timestamp token is empty")]
+    TimestampTokenEmpty,
+    #[error("Remote Authenticode TSA server response error: {0}")]
+    RemoteServerResponseError(reqwest::Error),
+    #[error("Badly formatted URL")]
+    BadUrl,
+}
+
+pub trait Timestamper: Sized {
+    fn timestamp(&self, digest: Vec<u8>, hash_algo: HashAlgorithm) -> Result<Pkcs7, TimestampError>; // hash_algo is used in RFC3161
+    fn modify_signed_data(&self, token: Pkcs7, signed_data: &mut SignedData);
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AuthenticodeTimestamper {
+    url: Url,
+}
+
+impl AuthenticodeTimestamper {
+    pub fn new<U: AsRef<str>>(url: U) -> Result<AuthenticodeTimestamper, TimestampError> {
+        let url = Url::parse(url.as_ref()).map_err(|_| TimestampError::BadUrl)?;
+        Ok(Self { url })
+    }
+}
+
+impl Timestamper for AuthenticodeTimestamper {
+    fn timestamp(&self, digest: Vec<u8>, _: HashAlgorithm) -> Result<Pkcs7, TimestampError> {
+        let timestamp_request = TimestampRequest {
+            countersignature_type: oids::timestamp_request().into(),
+            content: EncapsulatedContentInfo {
+                content_type: oids::pkcs7().into(),
+                content: Some(ContentValue::Data(digest.into()).into()),
+            },
+        };
+
+        let client = Client::new();
+        let content = picky_asn1_der::to_vec(&timestamp_request).map_err(TimestampError::Asn1DerError)?;
+
+        let request = client
+            .request(Method::POST, self.url.clone())
+            .header(CACHE_CONTROL, "no-cache")
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .header(CONTENT_LENGTH, content.len())
+            .body(content)
+            .build()
+            .expect("RequestBuilder should not panic");
+
+        let response = client
+            .execute(request)
+            .map_err(TimestampError::RemoteServerResponseError)?;
+
+        if response.status() != StatusCode::OK {
+            return Err(TimestampError::BadResponse(response.status()));
+        }
+
+        let body = response
+            .bytes()
+            .map_err(TimestampError::RemoteServerResponseError)?
+            .to_vec();
+
+        let token = picky_asn1_der::from_bytes::<Pkcs7Certificate>(&body).map_err(TimestampError::Asn1DerError)?;
+
+        Ok(token.into())
+    }
+
+    fn modify_signed_data(&self, token: Pkcs7, signed_data: &mut SignedData) {
+        let SignedData {
+            certificates,
+            signers_infos,
+            ..
+        } = token.0.signed_data.0;
+
+        let singer_info = signers_infos
+            .0
+            .first()
+            .expect("Exactly one SignedInfo should be present");
+
+        let unsigned_attribute = UnsignedAttribute {
+            ty: oids::counter_sign().into(),
+            value: UnsignedAttributeValue::CounterSign(vec![singer_info.clone()].into()),
+        };
+
+        let signer_info = signed_data
+            .signers_infos
+            .0
+             .0
+            .first_mut()
+            .expect("Exactly one SignedInfo should be present");
+
+        signer_info.unsigned_attrs.0 .0.push(unsigned_attribute);
+
+        signed_data.certificates.0 .0.extend(certificates.0 .0);
+    }
+}

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -137,6 +137,8 @@ impl TimestampRequest {
         &self.0.content
     }
 
+    pub fn into_content(self) -> EncapsulatedContentInfo { self.0.content }
+
     pub fn digest(&self) -> &[u8] {
         if let ExplicitContextTag0(ContentValue::Data(data)) = self.0.content.content.as_ref().unwrap() {
             &data.0


### PR DESCRIPTION
Added support for Authenticode timestamping for picky-signtool, and made Authenticode TSA server from picky-server.
There are two Authenticode timestamp protocols:
1) "Default" - https://docs.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures.
2) RFC3161
I have implemented the first one, but I was keeping in mind that we might add the second one. For Authenticode TSA server with default protocol, we don't need to use the database, but I added counting issued Authenticode timestamps as RFC3161 requires it, and we might add support for RFC3161 someday.
For timestamping Authenticode signature with picky-singtool, somebody should add `--timestamp <Authenticode TSA server URL>` arg. 