### PR TITLE
Fix Authenticode bugs that were found by QA

### DIFF
--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2.33"
 walkdir = "2.3"
 base64 = "0.13"
 encoding = "0.2"
-lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "8f439c" }
+lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "52dca2" }
 
 [dependencies.picky]
 path = "../picky"

--- a/picky-signtool/src/config.rs
+++ b/picky-signtool/src/config.rs
@@ -76,7 +76,7 @@ pub fn config() -> ArgMatches<'static> {
                 .help("Path to a Windows executable")
                 .takes_value(true)
                 .required(false)
-                .requires_all(&[ARG_BINARY, ARG_OUTPUT])
+                .requires(ARG_BINARY)
                 .validator(validate_executable_postfix)
                 .display_order(1),
         )
@@ -95,6 +95,7 @@ pub fn config() -> ArgMatches<'static> {
             Arg::with_name(ARG_PS_SCRIPT)
                 .long(ARG_PS_SCRIPT)
                 .help("Specify a PowerShell script or module to sign or verify")
+                .requires(ARG_SCRIPTS_PATH)
                 .display_order(3),
         )
         .arg(

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -179,18 +179,23 @@ impl AuthenticodeSignature {
 
         // certificates contains the signer certificate and any intermediate certificates,
         // but typically does not contain the root certificate
-        let certificates = certificates
-            .into_iter()
-            .filter_map(|cert| {
-                if cert.ty() != CertType::Root {
-                    Some(Certificate::from(cert))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<Certificate>>();
+        let certificates = if certificates.len() == 1 && certificates[0].ty() == CertType::Root {
+            vec![Certificate::from(certificates[0].clone())]
+        } else {
+            certificates
+                .into_iter()
+                .filter_map(|cert| {
+                    if cert.ty() != CertType::Root {
+                        Some(Certificate::from(cert))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<Certificate>>()
+        };
 
-        let signing_cert = certificates.get(0).ok_or(AuthenticodeError::NoCertificates)?;
+        let signing_cert = certificates.get(0);
+        let signing_cert = signing_cert.ok_or(AuthenticodeError::NoCertificates)?;
 
         let issuer_and_serial_number = IssuerAndSerialNumber {
             issuer: signing_cert.tbs_certificate.issuer.clone(),

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -194,8 +194,7 @@ impl AuthenticodeSignature {
                 .collect::<Vec<Certificate>>()
         };
 
-        let signing_cert = certificates.get(0);
-        let signing_cert = signing_cert.ok_or(AuthenticodeError::NoCertificates)?;
+        let signing_cert = certificates.get(0).ok_or(AuthenticodeError::NoCertificates)?;
 
         let issuer_and_serial_number = IssuerAndSerialNumber {
             issuer: signing_cert.tbs_certificate.issuer.clone(),


### PR DESCRIPTION
Fix that we cannot sign with just an end-entry self-signed root certificate.
Fix that `output` CLI parameter is required for verifying a binary. 