### PR TITLE
GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
           conan remote clean
           conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
 
-      - name: Build [{{ matrix.os }}]
+      - name: Build [${{ matrix.os }}]
         if: matrix.os == 'linux'
         run: |
          conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64 -s build_type=Release
          . activate.sh
          cargo build --release
 
-      - name: Build [{{ matrix.os }}]
+      - name: Build [${{ matrix.os }}]
         if: matrix.os == 'windows'
         env:
           RUSTFLAGS: '-C target-feature=+crt-static'
@@ -80,7 +80,8 @@ jobs:
         id: prepare-artifacts
         shell: pwsh
         run: |
-          $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky" "${{runner.os}}" "x86_64"
+          $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky"
+          $ArchDir = Join-Path $StagingDir "${{matrix.os}}" "x86_64"
           New-Item -Path $StagingDir -ItemType "directory"
 
           $Binaries = @("picky-server", "picky-signtool")
@@ -90,7 +91,7 @@ jobs:
           }
 
           Get-ChildItem -Recurse -Include $Binaries -File  | % {
-            Copy-Item -Path $_.FullName -Destination $StagingDir -Force 
+            Copy-Item -Path $_.FullName -Destination $ArchDir -Force 
           }
 
           echo "::set-output name=staging-dir::$StagingDir"
@@ -104,6 +105,7 @@ jobs:
   msrv:
     name: Check minimum rust version
     runs-on: ubuntu-18.04
+    needs: formatting
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           Write-Host "Check formatting"
           cargo fmt --all -- --check
 
-          if ($LastExitCode -eq 0) {   
+          if ($LastExitCode -eq 1) {   
             throw "Bad formatting, please run 'cargo +stable fmt --all'"
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         if: matrix.os == 'linux'
         run: |
-         conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64
+         conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64 -s build_type=Release
          . activate.sh
          cargo build --release
 
@@ -69,7 +69,7 @@ jobs:
         env:
           RUSTFLAGS: '-C target-feature=+crt-static'
         run: |
-         conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64
+         conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64 -s build_type=Release
          .\activate.ps1
          cargo build --release --target=x86_64-pc-windows-msvc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,30 @@ jobs:
       - name: Test
         run: cargo test --release --features "wincert","ctl","pkcs7"
 
+      - name: Prepare artifacts
+        id: prepare-artifacts
+        shell: pwsh
+        run: |
+          $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky" "${{runner.os}}" "x86_64"
+          $Binaries = @("picky-server", "picky-signtool")
+          
+          if ($Env:RUNNER_OS -Eq "Windows") {
+            $Binaries = $Binaries | ForEach-Object {"$_.exe"}
+          }
+
+          Get-ChildItem -Recurse -Include $Binaries -File  | % {
+            Copy-Item -Path $_.FullName -Destination $StagingDir -Force 
+          }
+
+          echo "::set-output name=staging-dir::$StagingDir"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: picky
+          path: ${{ steps.prepare-artifacts.outputs.staging-dir }}
+
+
+
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           }
 
   build:
-    name: picky [${{ matrix.os }}-${{ matrix.type }}]
+    name: picky ${{ matrix.type }} [${{ matrix.os }}]
     runs-on: ${{ matrix.runner }}
     needs: formatting
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           }
 
   build:
-    name: picky [${{ matrix.arch }}-${{ matrix.os }}]
+    name: picky [${{ matrix.os }}]
     runs-on: ${{ matrix.runner }}
     needs: formatting
     env:
@@ -40,6 +40,12 @@ jobs:
           
     steps:
       - uses: actions/checkout@v2
+
+      - name: Configure runner
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt update
+          sudo apt install python3-wget python3-setuptools
 
       - name: Install conan
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, linux ]
+        type: [ build, test ]
         include:
           - os: windows
             runner: windows-2019
@@ -58,14 +59,14 @@ jobs:
           conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
 
       - name: Build [${{ matrix.os }}]
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && matrix.type == 'build'
         run: |
          conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64 -s build_type=Release
          . activate.sh
          cargo build --release
 
       - name: Build [${{ matrix.os }}]
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows' && matrix.type == 'build'
         env:
           RUSTFLAGS: '-C target-feature=+crt-static'
         run: |
@@ -74,10 +75,12 @@ jobs:
          cargo build --release --target=x86_64-pc-windows-msvc
 
       - name: Test
+        if: matrix.type == 'test'
         run: cargo test --release --features "wincert","ctl","pkcs7"
 
       - name: Prepare artifacts
         id: prepare-artifacts
+        if: matrix.type == 'build'
         shell: pwsh
         run: |
           $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky"
@@ -98,6 +101,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
+        if: matrix.type == 'build'
         with:
           name: picky
           path: ${{ steps.prepare-artifacts.outputs.staging-dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
           conan remote clean
           conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
 
-      - name: Build
+      - name: Build [{{ matrix.os }}]
         if: matrix.os == 'linux'
         run: |
          conan install openssl/1.1.1l@devolutions/stable -g virtualenv -pr ${{ matrix.os }}-x86_64 -s build_type=Release
          . activate.sh
          cargo build --release
 
-      - name: Build
+      - name: Build [{{ matrix.os }}]
         if: matrix.os == 'windows'
         env:
           RUSTFLAGS: '-C target-feature=+crt-static'
@@ -81,6 +81,8 @@ jobs:
         shell: pwsh
         run: |
           $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky" "${{runner.os}}" "x86_64"
+          New-Item -Path $StagingDir -ItemType "directory"
+
           $Binaries = @("picky-server", "picky-signtool")
           
           if ($Env:RUNNER_OS -Eq "Windows") {
@@ -99,7 +101,29 @@ jobs:
           name: picky
           path: ${{ steps.prepare-artifacts.outputs.staging-dir }}
 
+  msrv:
+    name: Check minimum rust version
+    runs-on: ubuntu-18.04
 
+    steps:
+      - uses: actions/checkout@v2
 
+      - name: Configure runner 
+        run: |
+          set -e
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.43
+          rustup toolchain install 1.51
+
+      - name: cargo check picky-asn1
+        run: cargo +1.43 check -p picky-asn1
+
+      - name: cargo check picky-asn1-der
+        run: cargo +1.43 check -p picky-asn1-der
+        
+      - name: cargo check picky-asn1-x509
+        run: cargo +1.43 check -p picky-asn1-x509
+
+      - name: cargo check picky
+        run: cargo +1.51 check -p picky
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           }
 
   build:
-    name: picky [${{ matrix.os }}]
+    name: picky [${{ matrix.os }}-${{ matrix.type }}]
     runs-on: ${{ matrix.runner }}
     needs: formatting
     env:
@@ -74,7 +74,7 @@ jobs:
          .\activate.ps1
          cargo build --release --target=x86_64-pc-windows-msvc
 
-      - name: Test
+      - name: Test [${{ matrix.os }}]
         if: matrix.type == 'test'
         run: cargo test --release --features "wincert","ctl","pkcs7"
 
@@ -85,7 +85,7 @@ jobs:
         run: |
           $StagingDir = Join-Path "$Env:RUNNER_TEMP" "picky"
           $ArchDir = Join-Path $StagingDir "${{matrix.os}}" "x86_64"
-          New-Item -Path $StagingDir -ItemType "directory"
+          New-Item -Path $ArchDir -ItemType "directory"
 
           $Binaries = @("picky-server", "picky-signtool")
           
@@ -109,7 +109,7 @@ jobs:
   msrv:
     name: Check minimum rust version
     runs-on: ubuntu-18.04
-    needs: formatting
+    needs: build
 
     steps:
       - uses: actions/checkout@v2
@@ -121,15 +121,19 @@ jobs:
           rustup toolchain install 1.51
 
       - name: cargo check picky-asn1
+        continue-on-error: true
         run: cargo +1.43 check -p picky-asn1
 
       - name: cargo check picky-asn1-der
+        continue-on-error: true
         run: cargo +1.43 check -p picky-asn1-der
         
       - name: cargo check picky-asn1-x509
+        continue-on-error: true
         run: cargo +1.43 check -p picky-asn1-x509
 
       - name: cargo check picky
+        continue-on-error: true
         run: cargo +1.51 check -p picky
 
 


### PR DESCRIPTION
Finish the picky build in GitHub workflow. Build and tests are run in parallel on both Windows and Linux. The minimum rust version check runs after the build; this means we still have usable artifacts even if the workflow fails.

This won't replace AZ pipelines until we port the release pipeline over. 