### PR TITLE
Implement `time 0.3` types conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             runner: windows-2019
           - os: linux
             runner: ubuntu-18.04
-          
+
     steps:
       - uses: actions/checkout@v2
 
@@ -88,7 +88,7 @@ jobs:
           New-Item -Path $ArchDir -ItemType "directory"
 
           $Binaries = @("picky-server", "picky-signtool")
-          
+
           if ($Env:RUNNER_OS -Eq "Windows") {
             $Binaries = $Binaries | ForEach-Object {"$_.exe"}
           }
@@ -107,6 +107,9 @@ jobs:
           path: ${{ steps.prepare-artifacts.outputs.staging-dir }}
 
   msrv:
+    # Minimum supported Rust version check for published crates.
+    # If this break, bump crate version minor number.
+    # See https://github.com/Devolutions/picky-rs/issues/89
     name: Check minimum rust version
     runs-on: ubuntu-18.04
     needs: build
@@ -117,23 +120,21 @@ jobs:
       - name: Configure runner 
         run: |
           set -e
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.43
-          rustup toolchain install 1.51
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.56
 
       - name: cargo check picky-asn1
         continue-on-error: true
-        run: cargo +1.43 check -p picky-asn1
+        run: cargo +1.56 check -p picky-asn1
 
       - name: cargo check picky-asn1-der
         continue-on-error: true
-        run: cargo +1.43 check -p picky-asn1-der
-        
+        run: cargo +1.56 check -p picky-asn1-der
+
       - name: cargo check picky-asn1-x509
         continue-on-error: true
-        run: cargo +1.43 check -p picky-asn1-x509
+        run: cargo +1.56 check -p picky-asn1-x509
 
       - name: cargo check picky
         continue-on-error: true
-        run: cargo +1.51 check -p picky
-
+        run: cargo +1.56 check -p picky
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2333ac5777aaa1beb8589f5374976ae7dc8aa4f09fd21ae3d8662ca97f5247d"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee2263805ba4537ccbb19db28525a7b1ebc7284c228eb5634c3124ca63eb03f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arc-swap"
@@ -99,6 +99,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -187,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -198,7 +204,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2607a74355ce2e252d0c483b2d8a348e1bba36036e786ccc2dcd777213c86ffd"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if 1.0.0",
  "constant_time_eq",
 ]
 
@@ -306,13 +325,14 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cab"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398bd970880c9b8f34539efdc4a7b86844b48863f98e53e540de49b92315f42e"
+checksum = "d789f1af9f1c827b64e2e442f23022e118a6dd34c20f29dc098b7f951f9b14aa"
 dependencies = [
  "byteorder",
  "chrono",
  "flate2",
+ "lzxd",
 ]
 
 [[package]]
@@ -425,18 +445,12 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crc32fast"
@@ -449,16 +463,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.0",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -475,12 +489,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools",
 ]
 
 [[package]]
@@ -583,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -884,9 +898,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -899,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -909,15 +923,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -926,16 +940,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
+ "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -944,22 +959,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
+ "autocfg 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1017,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6fb2a26dd2ebd268a68bc8e9acc9e67e487952f33384055a1cbe697514c64e"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -1059,7 +1075,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.5.0",
+ "tokio 1.13.0",
  "tokio-util 0.6.6",
  "tracing",
 ]
@@ -1123,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1213,7 +1229,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2 0.4.0",
- "tokio 1.5.0",
+ "tokio 1.13.0",
  "tower-service",
  "tracing",
  "want",
@@ -1244,7 +1260,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper 0.14.5",
  "native-tls",
- "tokio 1.5.0",
+ "tokio 1.13.0",
  "tokio-native-tls",
 ]
 
@@ -1315,7 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2 0.3.19",
- "widestring",
+ "widestring 0.4.3",
  "winapi 0.3.9",
  "winreg 0.6.2",
 ]
@@ -1325,15 +1341,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1352,9 +1359,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1406,7 +1413,7 @@ dependencies = [
  "lief-sys",
  "picky 6.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "thiserror",
- "widestring",
+ "widestring 0.4.3",
 ]
 
 [[package]]
@@ -1483,6 +1490,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lzxd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784462f20dddd9dfdb45de963fa4ad4a288cb10a7889ac5d2c34fb6481c6b213"
 
 [[package]]
 name = "match_cfg"
@@ -1691,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "mongodm"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f0e5d65cd31974d4f8fe70a60fd251db5f16b5cf727e29f83dbe9263df35bd"
+checksum = "e80236d914949d0c206c1902c25e8b9292fac745b2ceb5774aa354c307caa6a4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1714,24 +1727,41 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.11.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+checksum = "49e540106213dc639fe2b632a7d9e3525169ef081378a7c2da4457b84fec44c0"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
+ "blake3",
  "digest 0.9.0",
- "sha-1 0.9.4",
- "sha2 0.9.3",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha-1 0.9.8",
+ "sha2 0.9.8",
  "sha3",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
+name = "multihash-derive"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1778,7 +1808,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.3",
+ "rand 0.8.4",
  "serde",
  "smallvec",
  "zeroize",
@@ -2000,14 +2030,14 @@ dependencies = [
  "picky-asn1-der 0.2.5",
  "picky-asn1-x509 0.6.1",
  "pretty_assertions",
- "rand 0.8.3",
- "reqwest 0.11.3",
+ "rand 0.8.4",
+ "reqwest 0.11.6",
  "ring",
  "rsa",
  "serde",
  "serde_json",
- "sha-1 0.9.4",
- "sha2 0.9.3",
+ "sha-1 0.9.8",
+ "sha2 0.9.8",
  "sha3",
  "thiserror",
  "time 0.3.4",
@@ -2029,12 +2059,12 @@ dependencies = [
  "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "picky-asn1-x509 0.6.1 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rsa",
  "serde",
  "serde_json",
- "sha-1 0.9.4",
- "sha2 0.9.3",
+ "sha-1 0.9.8",
+ "sha2 0.9.8",
  "sha3",
  "thiserror",
 ]
@@ -2097,7 +2127,7 @@ dependencies = [
  "picky-asn1-der 0.2.5",
  "pretty_assertions",
  "serde",
- "widestring",
+ "widestring 0.5.1",
 ]
 
 [[package]]
@@ -2111,7 +2141,7 @@ dependencies = [
  "picky-asn1 0.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "picky-asn1-der 0.2.5 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
  "serde",
- "widestring",
+ "widestring 0.4.3",
 ]
 
 [[package]]
@@ -2130,8 +2160,8 @@ dependencies = [
  "multihash",
  "picky 6.4.0",
  "picky-asn1 0.4.0",
- "rand 0.8.3",
- "reqwest 0.11.3",
+ "rand 0.8.4",
+ "reqwest 0.11.6",
  "saphir",
  "serde",
  "serde_json",
@@ -2226,9 +2256,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2266,10 +2296,11 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864231b0b86ce05168a8e6da0fea2e67275dacf25f75b00a62cfd341aab904a9"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
@@ -2283,14 +2314,24 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pretty_assertions"
-version = "0.7.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
 dependencies = [
  "ansi_term 0.12.1",
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -2369,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -2558,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -2580,8 +2621,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite 0.2.6",
  "serde",
+ "serde_json",
  "serde_urlencoded",
- "tokio 1.5.0",
+ "tokio 1.13.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -2630,7 +2672,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand 0.8.3",
+ "rand 0.8.4",
  "subtle 2.4.0",
  "zeroize",
 ]
@@ -2805,9 +2847,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -2843,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2854,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2901,12 +2943,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
 dependencies = [
  "dtoa",
- "linked-hash-map",
+ "indexmap",
  "serde",
  "yaml-rust 0.4.5",
 ]
@@ -2925,13 +2967,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2950,13 +2992,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -3101,7 +3143,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall 0.2.6",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -3118,18 +3160,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3218,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -3229,6 +3271,7 @@ dependencies = [
  "mio 0.7.11",
  "num_cpus",
  "pin-project-lite 0.2.6",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3249,7 +3292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.5.0",
+ "tokio 1.13.0",
 ]
 
 [[package]]
@@ -3312,7 +3355,16 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.5.0",
+ "tokio 1.13.0",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3496,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
 
 [[package]]
 name = "untrusted"
@@ -3580,9 +3632,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3592,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3619,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3629,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3642,15 +3694,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3689,6 +3741,12 @@ name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -1386,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libm"
@@ -1399,7 +1399,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "lief-rs"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/lief-rs.git?rev=8f439c#8f439c2397035eb5e1d72277dd12eb0717930d67"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=52dca2#52dca2b5795a54e110b6210c07ce1d2c41fd974a"
 dependencies = [
  "bitflags",
  "image",
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "lief-sys"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/lief-rs.git?rev=8f439c#8f439c2397035eb5e1d72277dd12eb0717930d67"
+source = "git+https://github.com/Devolutions/lief-rs.git?rev=52dca2#52dca2b5795a54e110b6210c07ce1d2c41fd974a"
 dependencies = [
  "cmake",
 ]
@@ -1677,7 +1677,7 @@ dependencies = [
  "stringprep",
  "strsim 0.10.0",
  "take_mut",
- "time",
+ "time 0.1.44",
  "tokio 0.2.25",
  "tokio-rustls 0.13.1",
  "trust-dns-proto",
@@ -2010,6 +2010,7 @@ dependencies = [
  "sha2 0.9.3",
  "sha3",
  "thiserror",
+ "time 0.3.4",
 ]
 
 [[package]]
@@ -2047,6 +2048,7 @@ dependencies = [
  "picky-asn1-der 0.2.5",
  "serde",
  "serde_bytes",
+ "time 0.3.4",
 ]
 
 [[package]]
@@ -2117,7 +2119,6 @@ name = "picky-server"
 version = "4.9.0"
 dependencies = [
  "base64 0.13.0",
- "chrono",
  "clap",
  "criterion",
  "futures",
@@ -2136,6 +2137,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "time 0.3.4",
  "tokio 0.2.25",
  "tokio-test",
  "unicase",
@@ -2722,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebbfddbcede862061268cdcf2657ebb430d139d33d82932f0f7accc3a78bff74"
 dependencies = [
  "chrono",
- "time",
+ "time 0.1.44",
 ]
 
 [[package]]
@@ -3154,6 +3156,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "picky",
     "picky-server",

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -108,6 +108,6 @@ jobs:
         displayName: cargo check picky-asn1-der
       - script: cargo +1.56 check -p picky-asn1-x509
         displayName: cargo check picky-asn1-x509
-      - script: cargo +1.51 check -p picky
+      - script: cargo +1.56 check -p picky
         displayName: cargo check picky
 

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -100,14 +100,13 @@ jobs:
     steps:
       - script: |
           set -e
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.43
-          rustup toolchain install 1.51
-        displayName: "Install rust 1.43 and 1.51"
-      - script: cargo +1.43 check -p picky-asn1
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.56
+        displayName: "Install rust 1.56"
+      - script: cargo +1.56 check -p picky-asn1
         displayName: cargo check picky-asn1
-      - script: cargo +1.43 check -p picky-asn1-der
+      - script: cargo +1.56 check -p picky-asn1-der
         displayName: cargo check picky-asn1-der
-      - script: cargo +1.43 check -p picky-asn1-x509
+      - script: cargo +1.56 check -p picky-asn1-x509
         displayName: cargo check picky-asn1-x509
       - script: cargo +1.51 check -p picky
         displayName: cargo check picky

--- a/picky-asn1-der/CHANGELOG.md
+++ b/picky-asn1-der/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Bump minimal rustc version to 1.56
+
 ## [0.2.5] 2021-05-27
 
 ### Added

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "picky-asn1-der"
 version = "0.2.5"
-edition = "2018"
+edition = "2021"
 authors = [
     "KizzyCode Software Labs./Keziah Biermann <development@kizzycode.de>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -17,16 +17,16 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_bytes = "0.11"
-lazy_static = { version = "1.4", optional = true }
+serde = { version = "1.0.130", default-features = false, features = ["derive"] }
+serde_bytes = "0.11.5"
+lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
-base64 = "0.13"
-pretty_assertions = "0.7"
-serde_bytes = "0.11"
-num-bigint-dig = "0.7"
-oid = { version = "0.2", default-features = false, features = ["serde_support"] }
+base64 = "0.13.0"
+pretty_assertions = "1.0.0"
+serde_bytes = "0.11.5"
+num-bigint-dig = "0.7.0"
+oid = { version = "0.2.1", default-features = false, features = ["serde_support"] }
 
 [features]
 debug_log = ["lazy_static"]

--- a/picky-asn1-der/tests/pki_tests/version.rs
+++ b/picky-asn1-der/tests/pki_tests/version.rs
@@ -25,10 +25,6 @@ impl Version {
             _ => None,
         }
     }
-
-    fn is_default(&self) -> bool {
-        self == &Self::V1
-    }
 }
 
 impl Serialize for Version {

--- a/picky-asn1-der/tests/serde_der_advanced_asn1_types.rs
+++ b/picky-asn1-der/tests/serde_der_advanced_asn1_types.rs
@@ -11,7 +11,6 @@ use picky_asn1::wrapper::*;
 use pretty_assertions::assert_eq;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::str::FromStr;
 

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Breaking) Add `SpcStatementType` variant in `AttributeValues` enum
 - (Breaking) Add `SigningTime` variant in `AttributeValues` enum
 - `SpcAttributeAndOptionalValue` now supports both `SpcPeImageData` and `SpcSipInfo` values
+- Bump minimal rustc version to 1.56
 
 ### Fixed
 

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -18,16 +18,16 @@ repository = "https://github.com/Devolutions/picky-rs"
 [dependencies]
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.2", path = "../picky-asn1-der" }
-serde = { version = "1.0", features = ["derive"] }
-oid = { version = "0.2", features = ["serde_support"] }
-base64 = "0.13"
-num-bigint-dig = { version = "0.7", optional = true }
-widestring = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
+serde = { version = "1.0.130", features = ["derive"] }
+oid = { version = "0.2.1", features = ["serde_support"] }
+base64 = "0.13.0"
+num-bigint-dig = { version = "0.7.0", optional = true }
+widestring = { version = "0.5.1", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
-num-bigint-dig = "0.7"
-pretty_assertions = "0.7"
-hex = "0.4"
+num-bigint-dig = "0.7.0"
+pretty_assertions = "1.0.0"
+hex = "0.4.3"
 
 [features]
 legacy = ["num-bigint-dig"]

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",
 ]
 description = "Provides ASN1 types defined by X.509 related RFCs"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 

--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -1,5 +1,4 @@
 use crate::oids;
-use oid::prelude::TryFrom;
 use oid::ObjectIdentifier;
 use picky_asn1::tag::{Tag, TagPeeker};
 use picky_asn1::wrapper::{IntegerAsn1, ObjectIdentifierAsn1, OctetStringAsn1};

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -21,11 +21,10 @@ macro_rules! define_oid {
     ($uppercase:ident => $lowercase:ident => $str_value:literal) => {
         pub const $uppercase: &'static str = $str_value;
 
-        pub fn $lowercase() -> oid::ObjectIdentifier {
-            use std::sync::Once;
-            use std::convert::TryInto;
+        pub fn $lowercase() -> ::oid::ObjectIdentifier {
+            use ::std::sync::Once;
 
-            static mut OID: Option<oid::ObjectIdentifier> = None;
+            static mut OID: Option<::oid::ObjectIdentifier> = None;
             static INIT: Once = Once::new();
             unsafe {
                 INIT.call_once(|| {

--- a/picky-asn1-x509/src/pkcs7/content_info.rs
+++ b/picky-asn1-x509/src/pkcs7/content_info.rs
@@ -1,8 +1,3 @@
-use std::convert::{Into, TryFrom};
-
-use serde::{de, ser, Deserialize, Serialize};
-use widestring::U16String;
-
 use picky_asn1::bit_string::BitString;
 use picky_asn1::restricted_string::{BMPString, CharSetError};
 use picky_asn1::tag::{TagClass, TagPeeker};
@@ -10,6 +5,8 @@ use picky_asn1::wrapper::{
     BMPStringAsn1, BitStringAsn1, ExplicitContextTag0, ExplicitContextTag1, ExplicitContextTag2, IA5StringAsn1,
     ImplicitContextTag0, ImplicitContextTag1, IntegerAsn1, ObjectIdentifierAsn1, OctetStringAsn1, Optional,
 };
+use serde::{de, ser, Deserialize, Serialize};
+use widestring::U16String;
 
 #[cfg(feature = "ctl")]
 use super::ctl::Ctl;

--- a/picky-asn1/CHANGELOG.md
+++ b/picky-asn1/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Optional::is_default`
+- Support for `time 0.3` types conversions behind `time_conversion` feature gate
+
+### Changed
+
+- Bump minimal rustc version to 1.56
 
 ## [0.4.0] 2021-08-09
 

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -14,11 +14,11 @@ repository = "https://github.com/Devolutions/picky-rs"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-oid = { version = "0.2", default-features = false, features = ["serde_support"] }
-serde_bytes = "0.11"
-chrono = { version = "0.4", optional = true }
-time = { version = "0.3", optional = true }
+serde = { version = "1.0.130", default-features = false, features = ["derive"] }
+oid = { version = "0.2.1", default-features = false, features = ["serde_support"] }
+serde_bytes = "0.11.5"
+chrono = { version = "0.4.19", optional = true }
+time = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 picky-asn1-der = { path = "../picky-asn1-der" }

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "picky-asn1"
 version = "0.4.0"
-edition = "2018"
+edition = "2021"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -16,11 +16,13 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 oid = { version = "0.2", default-features = false, features = ["serde_support"] }
-chrono = { version = "0.4", optional = true }
 serde_bytes = "0.11"
+chrono = { version = "0.4", optional = true }
+time = { version = "0.3", optional = true }
 
 [dev-dependencies]
 picky-asn1-der = { path = "../picky-asn1-der" }
 
 [features]
 chrono_conversion = ["chrono"]
+time_conversion = ["time"]

--- a/picky-asn1/src/date.rs
+++ b/picky-asn1/src/date.rs
@@ -1,5 +1,4 @@
 use serde::{de, ser, Deserializer, Serializer};
-use std::convert::TryFrom;
 use std::fmt;
 
 pub trait TimeRepr

--- a/picky-server/CHANGELOG.md
+++ b/picky-server/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump minimal rustc version to 1.56
+
 ## [4.8.0] 2020-11-20
 
 ### Changed

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Johann Dufaud <jdufaud@devolutions.net>",
 ]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
-picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "chrono_conversion", "pkcs7" ], path = "../picky" }
+picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "time_conversion", "pkcs7"], path = "../picky" }
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 mongodm = { version = "0.6", features = ["tokio-runtime"] }
 clap = { features = ["yaml"], version = "2.32" }
@@ -23,7 +23,7 @@ multihash = "0.11" # v0.12 removed support for Sha1 because it's not cryptograph
 multibase = "0.9"
 log = "0.4"
 log4rs = "1"
-chrono = "0.4"
+time = "0.3"
 base64 = "0.13"
 hex = "0.4"
 thiserror = "1.0"

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -13,30 +13,30 @@ repository = "https://github.com/Devolutions/picky-rs"
 [dependencies]
 picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "time_conversion", "pkcs7"], path = "../picky" }
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
-mongodm = { version = "0.6", features = ["tokio-runtime"] }
-clap = { features = ["yaml"], version = "2.32" }
-saphir = { version = "2.7", features = ["macro"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.8"
-multihash = "0.11" # v0.12 removed support for Sha1 because it's not cryptographically secure, but we need to support it for now
-multibase = "0.9"
-log = "0.4"
-log4rs = "1"
-time = "0.3"
-base64 = "0.13"
-hex = "0.4"
-thiserror = "1.0"
-unicase = "2.6"
-rand = { version = "0.8", optional = true }
+mongodm = { version = "0.7.3", features = ["tokio-runtime"] }
+clap = { features = ["yaml"], version = "2.33.3" }
+saphir = { version = "2.8.2", features = ["macro"] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+serde_yaml = "0.8.21"
+multihash = { version = "0.15.0", features = ["sha1", "secure-hashes", "std", "multihash-impl"], default-features = false }
+multibase = "0.9.1"
+log = "0.4.14"
+log4rs = "1.0.0"
+time = "0.3.4"
+base64 = "0.13.0"
+hex = "0.4.3"
+thiserror = "1.0.30"
+unicase = "2.6.0"
+rand = { version = "0.8.4", optional = true }
 tokio = "0.2"
-futures = "0.3"
+futures = "0.3.17"
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.8.4"
 tokio-test = "0.2"
-criterion = "0.3"
-reqwest = "0.11"
+criterion = "0.3.5"
+reqwest = "0.11.6"
 
 [features]
 pre-gen-pk = ["rand"]

--- a/picky-server/src/db/mongodb/mod.rs
+++ b/picky-server/src/db/mongodb/mod.rs
@@ -14,7 +14,6 @@ use mongodm::mongo::{Client, Database};
 use mongodm::{f, ToRepository};
 use picky::x509::Cert;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use thiserror::Error;
 
 const DB_CONNECTION_TIMEOUT_SECS: u64 = 15;

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -435,7 +435,7 @@ async fn sign_certificate(
         &ca_pk,
         config.signing_algorithm,
         &dns_name,
-        chrono::Duration::seconds(
+        time::Duration::seconds(
             i64::try_from(duration_secs).map_err(|e| format!("invalid x509 duration (too big?): {}", e))?,
         ),
     )

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -16,7 +16,6 @@ use saphir::prelude::*;
 use saphir::response::Builder as ResponseBuilder;
 use serde_json::{self, Value};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub struct ServerController {

--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -1,4 +1,4 @@
-use crate::addressing::{convert_to_canonical_base, CANONICAL_HASH};
+use crate::addressing::{convert_to_canonical_base, CANONICAL_HASH_CODE};
 use crate::config::{CertKeyPair, Config};
 use crate::db::{get_storage, BoxedPickyStorage, CertificateEntry, PickyStorage};
 use crate::http::authorization::{check_authorization, ProviderClaims};
@@ -177,7 +177,7 @@ impl ServerController {
     async fn get_cert(&self, multihash: String, req: Request) -> Result<ResponseBuilder, StatusCode> {
         let addressing_hash_any_base = multihash;
         let (addressing_hash, hash) = convert_to_canonical_base(&addressing_hash_any_base).internal_error()?;
-        let canonical_address = if hash == CANONICAL_HASH {
+        let canonical_address = if hash == CANONICAL_HASH_CODE {
             addressing_hash
         } else {
             let converted = self

--- a/picky-server/src/picky_controller.rs
+++ b/picky-server/src/picky_controller.rs
@@ -60,9 +60,9 @@ impl Picky {
         signature_hash_type: SignatureAlgorithm,
     ) -> Result<Cert, PickyError> {
         // validity
-        let now = chrono::offset::Utc::now();
+        let now = time::OffsetDateTime::now_utc();
         let valid_from = UTCDate::from(now);
-        let valid_to = UTCDate::from(now + chrono::Duration::days(DEFAULT_ROOT_DURATION_DAYS));
+        let valid_to = UTCDate::from(now + time::Duration::days(DEFAULT_ROOT_DURATION_DAYS));
 
         let mut key_usage = KeyUsage::default();
         key_usage.set_key_cert_sign(true);
@@ -86,9 +86,9 @@ impl Picky {
         signature_hash_type: SignatureAlgorithm,
     ) -> Result<Cert, PickyError> {
         // validity
-        let now = chrono::offset::Utc::now();
+        let now = time::OffsetDateTime::now_utc();
         let valid_from = UTCDate::from(now);
-        let valid_to = UTCDate::from(now + chrono::Duration::days(DEFAULT_INTERMEDIATE_DURATION_DAYS));
+        let valid_to = UTCDate::from(now + time::Duration::days(DEFAULT_INTERMEDIATE_DURATION_DAYS));
 
         let subject_name = DirectoryName::new_common_name(intermediate_name);
 
@@ -115,11 +115,11 @@ impl Picky {
         issuer_key: &PrivateKey,
         signature_hash_type: SignatureAlgorithm,
         dns_name: &str,
-        validity_duration: chrono::Duration,
+        validity_duration: time::Duration,
     ) -> Result<Cert, PickyError> {
         // validity
-        let now = chrono::offset::Utc::now();
-        let valid_from = UTCDate::from(now - chrono::Duration::minutes(INITIAL_VALIDITY_MARGIN_MINUTES));
+        let now = time::OffsetDateTime::now_utc();
+        let valid_from = UTCDate::from(now - time::Duration::minutes(INITIAL_VALIDITY_MARGIN_MINUTES));
         let valid_to = UTCDate::from(now + validity_duration);
 
         let mut key_usage = KeyUsage::default();

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 description = "A signtool like Authenticode sign and verify tool based on picky and lief-rs"
 
 [dependencies]
-anyhow = "1.0"
-clap = "2.33"
-walkdir = "2.3"
-base64 = "0.13"
-encoding = "0.2"
+anyhow = "1.0.45"
+clap = "2.33.3"
+walkdir = "2.3.2"
+base64 = "0.13.0"
+encoding = "0.2.33"
 lief-rs = { git = "https://github.com/Devolutions/lief-rs.git", rev = "52dca2" }
 
 [dependencies.picky]

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -2,7 +2,7 @@
 name = "picky-signtool"
 version = "0.1.0"
 authors = [ "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>" ]
-edition = "2018"
+edition = "2021"
 description = "A signtool like Authenticode sign and verify tool based on picky and lief-rs"
 
 [dependencies]

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -40,11 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add  Authenticode timestamp request struct - `TimestampRequest`
 - Add `AuthenticodeBuilder` for easier `AuthenticodeSignature` creation
 - Add `SignatureAlgorithm::hash_algorithm`
+- Support for `time 0.3` types conversions behind `time_conversion` feature gate
 
 ### Changed
 
 - (Breaking) Move Authenticode related code from `picky::x509::wincert` to `picky::x509::pkcs7::authenticode` module
 - (Breaking) Authenticode implementation is now behind `pkcs7` feature
+- Bump minimal rustc version to 1.56
 
 ### Fixed
 - Fix `BufReader` panic in `WinCertificate::decode` and `WinCertificate::encode` if data len is bigger than default capacity.

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -30,8 +30,11 @@ chrono = { version = "0.4.19", optional = true }
 time = { version = "0.3.4", optional = true }
 serde_json = { version = "1.0.68", optional = true }
 http = { version = "0.2.5", optional = true }
-reqwest = { version = "0.11.6", default-features = false, features = ["blocking"], optional = true }
 cab = { version = "0.3.0", optional = true }
+
+# FIXME: either use ureq, or even better: do not require this kind of dependency at all to let user decide which lib to use.
+# (currently users should *really* not forget to use `spawn_blocking` when calling associated functions from async context)
+reqwest = { version = "0.11.6", default-features = false, features = ["blocking"], optional = true }
 
 # /!\ ===== cryptography dependencies ===== /!\
 # These should be updated as soon as possible.

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Portable X.509, PKI, JOSE and HTTP signature implementation."
 keywords = ["x509", "jwt", "signature", "jose", "pki"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.13"
 thiserror = "1"
 byteorder = { version = "1.4", optional = true }
 chrono = { version = "0.4", optional = true }
+time = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 http = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
@@ -67,3 +68,4 @@ ctl_http_fetch = ["reqwest", "cab"]
 wincert = ["byteorder"]
 http_trait_impl = ["http"]
 chrono_conversion = ["chrono", "picky-asn1/chrono_conversion"]
+time_conversion = ["time", "picky-asn1/time_conversion"]

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -21,36 +21,36 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 picky-asn1 = { version = "0.4", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.2", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.6", path = "../picky-asn1-x509", features = ["legacy"] }
-serde = { version = "1.0", features = ["derive"] }
-oid = { version = "0.2", features = ["serde_support"] }
-base64 = "0.13"
-thiserror = "1"
-byteorder = { version = "1.4", optional = true }
-chrono = { version = "0.4", optional = true }
-time = { version = "0.3", optional = true }
-serde_json = { version = "1.0", optional = true }
-http = { version = "0.2", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
-cab = { version = "0.2", optional = true }
+serde = { version = "1.0.130", features = ["derive"] }
+oid = { version = "0.2.1", features = ["serde_support"] }
+base64 = "0.13.0"
+thiserror = "1.0.30"
+byteorder = { version = "1.4.3", optional = true }
+chrono = { version = "0.4.19", optional = true }
+time = { version = "0.3.4", optional = true }
+serde_json = { version = "1.0.68", optional = true }
+http = { version = "0.2.5", optional = true }
+reqwest = { version = "0.11.6", default-features = false, features = ["blocking"], optional = true }
+cab = { version = "0.3.0", optional = true }
 
 # /!\ ===== cryptography dependencies ===== /!\
 # These should be updated as soon as possible.
 # /!\ ===================================== /!\
-md-5 = "0.9"
-sha1 = { package = "sha-1", version = "0.9" }
-sha2 = "0.9"
-sha3 = "0.9"
-digest = "0.9"
-rsa = "0.5"
-rand = "0.8"
-num-bigint-dig = "0.7"
-aes-gcm = { version = "0.9", optional = true }
+md-5 = "0.9.1"
+sha1 = { package = "sha-1", version = "0.9.8" }
+sha2 = "0.9.8"
+sha3 = "0.9.1"
+digest = "0.9.0"
+rsa = "0.5.0"
+rand = "0.8.4"
+num-bigint-dig = "0.7.0"
+aes-gcm = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.7"
-hex = "0.4"
-cfg-if = "1"
-ring = "0.16"
+pretty_assertions = "1.0.0"
+hex = "0.4.3"
+cfg-if = "1.0.0"
+ring = "0.16.20"
 
 [features]
 default = ["x509", "jose", "http_signature", "http_trait_impl"]

--- a/picky/README.md
+++ b/picky/README.md
@@ -2,7 +2,7 @@
 [![docs.rs](https://docs.rs/picky/badge.svg)](https://docs.rs/picky)
 ![Crates.io](https://img.shields.io/crates/l/picky)
 
-Compatible with rustc 1.51.
+Compatible with rustc 1.56.
 Minimal rustc version bumps happen [only with minor number bumps in this project](https://github.com/Devolutions/picky-rs/issues/89#issuecomment-868303478).
 
 # picky

--- a/picky/fuzz/Cargo.toml
+++ b/picky/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "picky-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/picky/src/hash.rs
+++ b/picky/src/hash.rs
@@ -3,7 +3,6 @@
 use digest::Digest;
 use picky_asn1_x509::ShaVariant;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 

--- a/picky/src/jose/jwe.rs
+++ b/picky/src/jose/jwe.rs
@@ -12,7 +12,6 @@ use rand::RngCore;
 use rsa::{PaddingScheme, PublicKey as RsaPublicKeyInterface, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use thiserror::Error;
 
 type Aes192Gcm = aes_gcm::AesGcm<aes_gcm::aes::Aes192, aes_gcm::aead::generic_array::typenum::U12>;

--- a/picky/src/jose/jws.rs
+++ b/picky/src/jose/jws.rs
@@ -7,7 +7,6 @@ use crate::jose::jwk::Jwk;
 use crate::key::{PrivateKey, PublicKey};
 use crate::signature::{SignatureAlgorithm, SignatureError};
 use base64::DecodeError;
-use core::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/picky/src/key.rs
+++ b/picky/src/key.rs
@@ -1,7 +1,6 @@
 //! Wrappers around public and private keys raw data providing an easy to use API
 
 use crate::pem::{parse_pem, to_pem, Pem, PemError};
-use core::convert::TryFrom;
 use num_bigint_dig::traits::ModInverse;
 use picky_asn1::wrapper::{BitStringAsn1Container, IntegerAsn1, OctetStringAsn1Container};
 use picky_asn1_der::Asn1DerError;

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -2,7 +2,6 @@
 
 use crate::hash::HashAlgorithm;
 use crate::key::{KeyError, PrivateKey, PublicKey};
-use core::convert::TryFrom;
 use picky_asn1_x509::{oids, AlgorithmIdentifier};
 use rsa::{PublicKey as _, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};

--- a/picky/src/x509/certificate.rs
+++ b/picky/src/x509/certificate.rs
@@ -16,7 +16,6 @@ use picky_asn1_x509::{
 };
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use std::convert::TryFrom;
 use thiserror::Error;
 
 const ELEMENT_NAME: &str = "x509 certificate";

--- a/picky/src/x509/date.rs
+++ b/picky/src/x509/date.rs
@@ -146,7 +146,6 @@ impl fmt::Display for UTCDate {
 #[cfg(feature = "time_conversion")]
 mod time_convert {
     use super::*;
-    use std::convert::{TryFrom, TryInto};
     use time::OffsetDateTime;
 
     impl From<OffsetDateTime> for UTCDate {

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -336,6 +336,7 @@ impl AuthenticodeSignature {
                 now: None,
                 excluded_cert_authorities: vec![],
                 expected_file_hash: None,
+                #[cfg(feature = "ctl")]
                 ctl: None,
             }),
         }
@@ -423,6 +424,7 @@ struct AuthenticodeValidatorInner<'a> {
     excluded_cert_authorities: Vec<DirectoryName>,
     now: Option<ValidityCheck<'a>>,
     expected_file_hash: Option<Vec<u8>>,
+    #[cfg(feature = "ctl")]
     ctl: Option<&'a CertificateTrustList>,
 }
 
@@ -1007,6 +1009,7 @@ fn h_check_eku_code_signing(certificates: &[Cert]) -> AuthenticodeResult<()> {
     Ok(())
 }
 
+#[cfg(feature = "ctl")]
 fn h_get_ca_name(certificates: &[Cert]) -> Option<DirectoryName> {
     if let Some(root) = certificates.iter().find(|cert| cert.ty() == CertType::Root) {
         Some(root.subject_name())

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -1,3 +1,7 @@
+pub use picky_asn1_x509::attribute::Attribute;
+pub use picky_asn1_x509::pkcs7::content_info;
+pub use picky_asn1_x509::ShaVariant;
+
 use crate::hash::{HashAlgorithm, UnsupportedHashAlgorithmError};
 use crate::key::PrivateKey;
 use crate::pem::Pem;
@@ -32,13 +36,7 @@ use picky_asn1_x509::pkcs7::signer_info::{
 };
 use picky_asn1_x509::pkcs7::Pkcs7Certificate;
 use picky_asn1_x509::{oids, AttributeValues, Certificate, DigestInfo, Name};
-
-pub use picky_asn1_x509::attribute::Attribute;
-pub use picky_asn1_x509::pkcs7::content_info;
-pub use picky_asn1_x509::ShaVariant;
-
 use std::cell::RefCell;
-use std::convert::TryFrom;
 use std::ops::DerefMut;
 use thiserror::Error;
 

--- a/picky/src/x509/pkcs7/timestamp.rs
+++ b/picky/src/x509/pkcs7/timestamp.rs
@@ -7,7 +7,9 @@ use picky_asn1::wrapper::ExplicitContextTag0;
 use picky_asn1_x509::oids;
 use picky_asn1_x509::pkcs7::content_info::{ContentValue, EncapsulatedContentInfo};
 use picky_asn1_x509::pkcs7::signed_data::SignedData;
+#[cfg(feature = "http_timestamp")]
 use picky_asn1_x509::pkcs7::signer_info::UnsignedAttribute;
+#[cfg(feature = "http_timestamp")]
 use picky_asn1_x509::signer_info::UnsignedAttributeValue;
 
 use thiserror::Error;

--- a/picky/src/x509/wincert.rs
+++ b/picky/src/x509/wincert.rs
@@ -1,5 +1,4 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::convert::TryFrom;
 use std::error;
 use std::io::{self, BufReader, BufWriter, Write};
 use thiserror::Error;


### PR DESCRIPTION
I also migrated to 2021 editions `picky`, `picky-server` and `picky-signtool`.