### PR TITLE
Elliptic curve private keys initial support 

### DIFF
--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -155,7 +155,7 @@ impl AlgorithmIdentifier {
         }
     }
 
-    pub fn new_elliptic_curve<P: Into<EcParameters>>(ec_params: P) -> Self {
+    pub fn new_elliptic_curve<P: Into<Option<EcParameters>>>(ec_params: P) -> Self {
         Self {
             algorithm: oids::ec_public_key().into(),
             parameters: AlgorithmIdentifierParameters::Ec(ec_params.into()),
@@ -306,7 +306,7 @@ pub enum AlgorithmIdentifierParameters {
     None,
     Null,
     Aes(AesParameters),
-    Ec(EcParameters),
+    Ec(Option<EcParameters>),
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -269,6 +269,7 @@ impl<'de> de::Deserialize<'de> for AlgorithmIdentifier {
                     }
                     oids::EC_PUBLIC_KEY => AlgorithmIdentifierParameters::Ec(seq_next_element!(
                         seq,
+                        Option<EcParameters>,
                         AlgorithmIdentifier,
                         "elliptic curves parameters"
                     )),

--- a/picky-asn1-x509/src/macros.rs
+++ b/picky-asn1-x509/src/macros.rs
@@ -37,6 +37,10 @@ mod tests {
             let encoded = &$encoded[$start..$end];
             check_serde!($item: $type in encoded);
         };
+        ($item:ident: $type:ident in $encoded:ident[$start:literal..]) => {
+            let encoded = &$encoded[$start..];
+            check_serde!($item: $type in encoded);
+        };
         ($item:ident: $type:ident in $encoded:ident) => {
             let encoded = &$encoded[..];
             let encoded_base64 = base64::encode(encoded);

--- a/picky-asn1-x509/src/macros.rs
+++ b/picky-asn1-x509/src/macros.rs
@@ -33,12 +33,8 @@ macro_rules! seq_next_element {
 #[macro_use]
 mod tests {
     macro_rules! check_serde {
-        ($item:ident: $type:ident in $encoded:ident[$start:literal..$end:literal]) => {
-            let encoded = &$encoded[$start..$end];
-            check_serde!($item: $type in encoded);
-        };
-        ($item:ident: $type:ident in $encoded:ident[$start:literal..]) => {
-            let encoded = &$encoded[$start..];
+        ($item:ident: $type:ident in $encoded:ident[$range:expr]) => {
+            let encoded = &$encoded[$range];
             check_serde!($item: $type in encoded);
         };
         ($item:ident: $type:ident in $encoded:ident) => {

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -44,6 +44,7 @@ define_oid! {
     DSA_WITH_SHA1 => dsa_with_sha1 => "1.2.840.10040.4.3",
     // ANSI-X962
     EC_PUBLIC_KEY => ec_public_key => "1.2.840.10045.2.1",
+    ANSIP521R1 => ansip521r1 => "1.3.132.0.35",
     ECDSA_WITH_SHA256 => ecdsa_with_sha256 => "1.2.840.10045.4.3.2",
     ECDSA_WITH_SHA384 => ecdsa_with_sha384 => "1.2.840.10045.4.3.3",
     ECDSA_WITH_SHA512 => ecdsa_with_sha512 => "1.2.840.10045.4.3.4",

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -44,7 +44,6 @@ define_oid! {
     DSA_WITH_SHA1 => dsa_with_sha1 => "1.2.840.10040.4.3",
     // ANSI-X962
     EC_PUBLIC_KEY => ec_public_key => "1.2.840.10045.2.1",
-    ANSIP521R1 => ansip521r1 => "1.3.132.0.35",
     ECDSA_WITH_SHA256 => ecdsa_with_sha256 => "1.2.840.10045.4.3.2",
     ECDSA_WITH_SHA384 => ecdsa_with_sha384 => "1.2.840.10045.4.3.3",
     ECDSA_WITH_SHA512 => ecdsa_with_sha512 => "1.2.840.10045.4.3.4",

--- a/picky-asn1-x509/src/private_key_info.rs
+++ b/picky-asn1-x509/src/private_key_info.rs
@@ -503,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn decoded_pkcs8_ec_key() {
+    fn decode_pkcs8_ec_key() {
         let decoded = base64::decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgKZqrmOg/cDZ4tPCn\
                                                             4LROs145nxx+ssufvflL8cROxFmhRANCAARmU90fCSTsncefY7hVeKw1WIg/YQmT\
                                                             4DGJ7nJPZ+WXAd/xxp4c0bHGlIOju/U95ITPN9dAmro7OUTDJpz+rzGW").unwrap();

--- a/picky-asn1-x509/src/private_key_info.rs
+++ b/picky-asn1-x509/src/private_key_info.rs
@@ -1,8 +1,11 @@
 use crate::{oids, AlgorithmIdentifier, EcParameters};
-use picky_asn1::{tag::{Tag, TagPeeker}, Asn1Type};
 use picky_asn1::wrapper::{
-    BitStringAsn1, ExplicitContextTag0, ExplicitContextTag1, HeaderOnly, IntegerAsn1,
-    OctetStringAsn1, OctetStringAsn1Container,
+    BitStringAsn1, ExplicitContextTag0, ExplicitContextTag1, HeaderOnly, IntegerAsn1, OctetStringAsn1,
+    OctetStringAsn1Container,
+};
+use picky_asn1::{
+    tag::{Tag, TagPeeker},
+    Asn1Type,
 };
 #[cfg(not(feature = "legacy"))]
 use serde::Deserialize;

--- a/picky-asn1-x509/src/subject_public_key_info.rs
+++ b/picky-asn1-x509/src/subject_public_key_info.rs
@@ -40,9 +40,9 @@ impl SubjectPublicKeyInfo {
             ),
         }
     }
-    pub fn new_ec_key<A: Into<EcParameters>, P: Into<BitStringAsn1>>(ec_params: A, ec_point: P) -> Self {
+    pub fn new_ec_key<P: Into<BitStringAsn1>>(ec_point: P) -> Self {
         Self {
-            algorithm: AlgorithmIdentifier::new_elliptic_curve(ec_params),
+            algorithm: AlgorithmIdentifier::new_elliptic_curve(EcParameters::NamedCurve(oids::ec_public_key().into())),
             subject_public_key: PublicKey::Ec(ec_point.into()),
         }
     }

--- a/picky-asn1-x509/src/subject_public_key_info.rs
+++ b/picky-asn1-x509/src/subject_public_key_info.rs
@@ -1,4 +1,4 @@
-use crate::{oids, AlgorithmIdentifier};
+use crate::{oids, AlgorithmIdentifier, EcParameters};
 use picky_asn1::wrapper::{BitStringAsn1, BitStringAsn1Container, IntegerAsn1, OctetStringAsn1};
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
@@ -38,6 +38,12 @@ impl SubjectPublicKeyInfo {
                 }
                 .into(),
             ),
+        }
+    }
+    pub fn new_ec_key<A: Into<EcParameters>, P: Into<BitStringAsn1>>(ec_params: A, ec_point: P) -> Self {
+        Self {
+            algorithm: AlgorithmIdentifier::new_elliptic_curve(ec_params),
+            subject_public_key: PublicKey::Ec(ec_point.into()),
         }
     }
 }

--- a/picky-asn1-x509/src/subject_public_key_info.rs
+++ b/picky-asn1-x509/src/subject_public_key_info.rs
@@ -40,6 +40,7 @@ impl SubjectPublicKeyInfo {
             ),
         }
     }
+
     pub fn new_ec_key<P: Into<BitStringAsn1>>(ec_point: P) -> Self {
         Self {
             algorithm: AlgorithmIdentifier::new_elliptic_curve(EcParameters::NamedCurve(oids::ec_public_key().into())),

--- a/picky-asn1/src/bit_string.rs
+++ b/picky-asn1/src/bit_string.rs
@@ -33,7 +33,7 @@ use serde::{de, ser};
 /// b.set(63, true);
 /// assert_eq!(b.is_set(63), false);
 /// ```
-#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct BitString {
     data: Vec<u8>,
 }
@@ -287,5 +287,11 @@ impl ser::Serialize for BitString {
         S: ser::Serializer,
     {
         serializer.serialize_bytes(&self.data)
+    }
+}
+
+impl Default for BitString {
+    fn default() -> Self {
+        BitString::with_len(0)
     }
 }

--- a/picky-asn1/src/bit_string.rs
+++ b/picky-asn1/src/bit_string.rs
@@ -33,7 +33,7 @@ use serde::{de, ser};
 /// b.set(63, true);
 /// assert_eq!(b.is_set(63), false);
 /// ```
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct BitString {
     data: Vec<u8>,
 }

--- a/picky-asn1/src/wrapper.rs
+++ b/picky-asn1/src/wrapper.rs
@@ -239,6 +239,12 @@ define_special_tag! {
     ImplicitContextTag15 => Tag::context_specific_primitive(15),
 }
 
+impl Default for BitStringAsn1 {
+    fn default() -> Self {
+        BitStringAsn1(BitString::default())
+    }
+}
+
 impl Default for IA5StringAsn1 {
     fn default() -> Self {
         IA5StringAsn1::from(IA5String::default())

--- a/picky/src/x509/certificate.rs
+++ b/picky/src/x509/certificate.rs
@@ -1503,8 +1503,12 @@ mod tests {
         let root = Cert::from_pem_str(crate::test_files::PSDIAG_ROOT).unwrap();
 
         let chain = [inter, root];
-        let now = UTCDate::now();
+        let unexpired_date = UTCDate::new(2021, 11, 21, 1, 0, 0).unwrap();
 
-        leaf.verifier().exact_date(&now).chain(chain.iter()).verify().unwrap();
+        leaf.verifier()
+            .exact_date(&unexpired_date)
+            .chain(chain.iter())
+            .verify()
+            .unwrap();
     }
 }


### PR DESCRIPTION
I added `EC` private keys encoding/decoding in `picky-asn1-x509`, support of `PrivateKey` to accept `EC` private keys.   
I will continue working on making `PrivateKey` API for `EC` private keys similar to the `RSA` ones, also on supporting `EC` signature. But, I will take some time to make myself more familiar with elliptic curves.  
This PR partially closes #100.  