### PR TITLE
Fix SSH certificate signature generation

### DIFF
--- a/picky/src/ssh/certificate.rs
+++ b/picky/src/ssh/certificate.rs
@@ -566,9 +566,6 @@ impl<'a> SshCertificateBuilder<'a> {
             buff.write_ssh_string(cert_key_type.as_str())
                 .map_err(SshCertificateGenerationError::IoError)?;
 
-            buff.write_ssh_string(cert_key_type.as_str())
-                .map_err(SshCertificateGenerationError::IoError)?;
-
             buff.write_ssh_bytes(&nonce)
                 .map_err(SshCertificateGenerationError::IoError)?;
 


### PR DESCRIPTION
I made an error that `cert_key_type` was deserialized twice while computing an `SSH` certificate signature while rebasing the ssh-ca branch to the latest master. This makes our `SSH` certificates' signatures incorrect. This PR fixes this.