### PR TITLE
Authenticode timestamping bug fixes

### DIFF
--- a/picky-signtool/src/lib.rs
+++ b/picky-signtool/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use lief::LogLevel;
 use std::path::Path;
 
 pub mod config;
@@ -6,10 +7,33 @@ pub mod sign;
 pub mod utils;
 pub mod verify;
 
+use config::{
+    ARG_LOGGING_CRITICAL, ARG_LOGGING_DEBUG, ARG_LOGGING_ERR, ARG_LOGGING_INFO, ARG_LOGGING_TRACE, ARG_LOGGING_WARN,
+};
+
 #[inline]
 pub fn get_utf8_file_name(file: &Path) -> anyhow::Result<&str> {
     file.file_name()
         .map(|name| name.to_str())
         .flatten()
         .ok_or_else(|| anyhow!("Invalid file name: {:?}", file))
+}
+
+#[inline]
+pub fn lief_logging(log_level: Option<&str>) {
+    match log_level {
+        Some(log_level) => {
+            let log_level = match log_level {
+                ARG_LOGGING_TRACE => LogLevel::LogTrace,
+                ARG_LOGGING_DEBUG => LogLevel::LogDebug,
+                ARG_LOGGING_INFO => LogLevel::LogInfo,
+                ARG_LOGGING_WARN => LogLevel::LogWarn,
+                ARG_LOGGING_ERR => LogLevel::LogErr,
+                ARG_LOGGING_CRITICAL => LogLevel::LogCritical,
+                _ => unreachable!("Unexpected log level value"),
+            };
+            lief::enable_logging(log_level);
+        }
+        None => lief::disable_logging(),
+    }
 }

--- a/picky-signtool/src/main.rs
+++ b/picky-signtool/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use walkdir::{DirEntry, WalkDir};
 
 use picky_signtool::config::*;
+use picky_signtool::lief_logging;
 use picky_signtool::sign::sign;
 use picky_signtool::verify::verify;
 
@@ -15,6 +16,8 @@ fn main() -> anyhow::Result<()> {
             let binary_path = matches
                 .value_of(ARG_INPUT)
                 .expect("Path to a Windows executable is required");
+
+            lief_logging(matches.value_of(ARG_LOGGING));
 
             vec![PathBuf::from(binary_path)]
         }

--- a/picky-signtool/src/sign.rs
+++ b/picky-signtool/src/sign.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
 use clap::ArgMatches;
-use lief::{Binary, LogLevel};
+use lief::Binary;
 
 use picky::hash::HashAlgorithm;
 use picky::key::PrivateKey;
@@ -14,10 +14,10 @@ use picky::x509::pkcs7::Pkcs7;
 use picky::x509::wincert::{CertificateType, WinCertificate};
 
 use crate::config::{
-    ARG_BINARY, ARG_LOGGING, ARG_LOGGING_CRITICAL, ARG_LOGGING_DEBUG, ARG_LOGGING_ERR, ARG_LOGGING_INFO,
-    ARG_LOGGING_TRACE, ARG_LOGGING_WARN, ARG_OUTPUT, ARG_PS_SCRIPT, ARG_TIMESTAMP, CRLF, PS_AUTHENTICODE_FOOTER,
-    PS_AUTHENTICODE_HEADER, PS_AUTHENTICODE_LINES_SPLITTER,
+    ARG_BINARY, ARG_OUTPUT, ARG_PS_SCRIPT, ARG_TIMESTAMP, CRLF, PS_AUTHENTICODE_FOOTER, PS_AUTHENTICODE_HEADER,
+    PS_AUTHENTICODE_LINES_SPLITTER,
 };
+
 use crate::get_utf8_file_name;
 use crate::utils::str_to_utf16_bytes;
 use crate::verify::extract_signed_ps_file_content_bytes;
@@ -73,22 +73,6 @@ pub fn sign(
             .context("Output path for signed binary is not specified")?;
 
         let binary_name = get_utf8_file_name(file.as_path())?;
-
-        match matches.value_of(ARG_LOGGING) {
-            Some(log_level) => {
-                let log_level = match log_level {
-                    ARG_LOGGING_TRACE => LogLevel::LogTrace,
-                    ARG_LOGGING_DEBUG => LogLevel::LogDebug,
-                    ARG_LOGGING_INFO => LogLevel::LogInfo,
-                    ARG_LOGGING_WARN => LogLevel::LogWarn,
-                    ARG_LOGGING_ERR => LogLevel::LogErr,
-                    ARG_LOGGING_CRITICAL => LogLevel::LogCritical,
-                    _ => unreachable!("Unexpected log level value"),
-                };
-                lief::enable_logging(log_level);
-            }
-            None => lief::disable_logging(),
-        }
 
         sign_binary(
             &pkcs7,

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -106,7 +106,7 @@ pub fn verify(matches: &ArgMatches, files: &[PathBuf]) -> anyhow::Result<()> {
         .cloned()
         .collect::<Vec<String>>();
 
-    let ctl = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CHAIN) {
+    let ctl = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CA) {
         let ctl = CertificateTrustList::fetch()?;
         Some(ctl)
     } else {
@@ -232,18 +232,18 @@ fn apply_flags<'a>(
     };
 
     let validator = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CHAIN) {
-        let validator = validator.require_chain_check();
-        if let Some(ctl) = ctl {
-            validator.ctl(ctl)
-        } else {
-            validator
-        }
+        validator.require_chain_check()
     } else {
         &validator
     };
 
     if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CA) {
-        validator.require_ca_against_ctl_check()
+        let validator = validator.require_ca_against_ctl_check();
+        if let Some(ctl) = ctl {
+            validator.ctl(ctl)
+        } else {
+            validator
+        }
     } else {
         validator
     }

--- a/picky/src/x509/name.rs
+++ b/picky/src/x509/name.rs
@@ -3,6 +3,7 @@ use picky_asn1::restricted_string::{CharSetError, IA5String};
 use picky_asn1::wrapper::{Asn1SequenceOf, IA5StringAsn1};
 use picky_asn1_x509::{
     DirectoryString, GeneralName as SerdeGeneralName, GeneralNames as SerdeGeneralNames, Name, NamePrettyFormatter,
+    OtherName,
 };
 use std::fmt;
 
@@ -66,6 +67,7 @@ impl From<DirectoryName> for Name {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum GeneralName {
+    OtherName(OtherName),
     RFC822Name(IA5String),
     DNSName(IA5String),
     DirectoryName(DirectoryName),
@@ -118,6 +120,7 @@ impl GeneralName {
 impl From<SerdeGeneralName> for GeneralName {
     fn from(gn: SerdeGeneralName) -> Self {
         match gn {
+            SerdeGeneralName::OtherName(other_name) => Self::OtherName(other_name),
             SerdeGeneralName::Rfc822Name(name) => Self::RFC822Name(name.0),
             SerdeGeneralName::DnsName(name) => Self::DNSName(name.0),
             SerdeGeneralName::DirectoryName(name) => Self::DirectoryName(name.into()),
@@ -135,6 +138,7 @@ impl From<SerdeGeneralName> for GeneralName {
 impl From<GeneralName> for SerdeGeneralName {
     fn from(gn: GeneralName) -> Self {
         match gn {
+            GeneralName::OtherName(other_name) => SerdeGeneralName::OtherName(other_name),
             GeneralName::RFC822Name(name) => SerdeGeneralName::Rfc822Name(name.into()),
             GeneralName::DNSName(name) => SerdeGeneralName::DnsName(name.into()),
             GeneralName::DirectoryName(name) => SerdeGeneralName::DirectoryName(name.into()),


### PR DESCRIPTION
1. picky-signtool:
- Fix that `LIEF` logs can appear while verifying a binary(even with binary logging turn off).
- Fix incorrect behavior of `ca` flags
2. picky Authenticode related code:
- Fix a chain verification if the chain also contains timestamp certificates
- Add parsing of `GeneralName::OtherName` as missing it causes incorrect validation of some binaries.