### PR TITLE
Add Access-Control-Max-Age to cache CORS preflight request responses

### DIFF
--- a/picky-server/src/http/middleware.rs
+++ b/picky-server/src/http/middleware.rs
@@ -1,3 +1,4 @@
+use saphir::http::header::HeaderValue;
 use saphir::prelude::*;
 
 pub async fn log_middleware(ctx: HttpContext, chain: &dyn MiddlewareChain) -> Result<HttpContext, SaphirError> {
@@ -22,6 +23,8 @@ pub async fn cors_middleware(ctx: HttpContext, chain: &dyn MiddlewareChain) -> R
     if let Some(origin_header) = origin_header {
         let res = ctx.state.response_mut().unwrap(); // should not panic because this is after chain.next(..) call
         res.headers_mut().insert("Access-Control-Allow-Origin", origin_header);
+        res.headers_mut()
+            .insert("Access-Control-Max-Age", HeaderValue::from_static("7200"));
     }
 
     Ok(ctx)


### PR DESCRIPTION
When making a cross-origin request, browsers need to make a preflight request (with the OPTIONS verb) to check if a CORS header is allowing it. The Access-Control-Max-Age lets browser cache the preflight response, reducing the number of OPTIONS requests that are needed. The value is set to 2 hours (7200 seconds) which is the maximum value allowed by Chrome. 