### PR TITLE
KDC proxy in DG related improvements

### DIFF
--- a/picky-asn1-der/src/application_tag.rs
+++ b/picky-asn1-der/src/application_tag.rs
@@ -1,0 +1,158 @@
+use crate::misc::Length;
+use crate::Asn1RawDer;
+use picky_asn1::tag::{Tag, TagPeeker};
+use serde::de::{Error, SeqAccess};
+use serde::{de, ser};
+use std::fmt;
+use std::fmt::Debug;
+
+#[derive(Debug, PartialEq)]
+pub struct ApplicationTag<V: Debug + PartialEq, const T: u8>(V);
+
+impl<V: Debug + PartialEq, const T: u8> ApplicationTag<V, T> {
+    pub fn from(value: V) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug)]
+struct ApplicationTagInner<V: Debug>(V);
+
+impl<'de, V: de::Deserialize<'de> + Debug + PartialEq> de::Deserialize<'de> for ApplicationTagInner<V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as de::Deserializer<'de>>::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor<E>(Option<E>);
+
+        impl<E> Visitor<E> {
+            pub fn new() -> Self {
+                Self(None)
+            }
+        }
+
+        impl<'de, E: de::Deserialize<'de> + Debug> de::Visitor<'de> for Visitor<E> {
+            type Value = ApplicationTagInner<E>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Error inner")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let res: E = seq
+                    .next_element()?
+                    .ok_or(A::Error::missing_field("ApplicationTagInner"))?;
+
+                Ok(ApplicationTagInner(res))
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor::<V>::new())
+    }
+}
+
+impl<'de, V: de::Deserialize<'de> + Debug + PartialEq, const T: u8> de::Deserialize<'de> for ApplicationTag<V, T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor<E>(Option<E>, u8);
+
+        impl<E> Visitor<E> {
+            pub fn new(tag: u8) -> Self {
+                Self(None, tag)
+            }
+        }
+
+        impl<'de, E: de::Deserialize<'de> + Debug + PartialEq> de::Visitor<'de> for Visitor<E> {
+            type Value = E;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Error inner")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let tag_peeker: TagPeeker = seq
+                    .next_element()
+                    .map_err(|e| A::Error::custom(format!("Cannot deserialize application tag: {:?}", e)))?
+                    .ok_or(A::Error::missing_field("ApplicationTag"))?;
+                let tag = tag_peeker.next_tag;
+
+                if !tag.is_application() {
+                    return Err(A::Error::custom(format!(
+                        "Expected Application class tag but got: {:?}",
+                        tag.class()
+                    )));
+                }
+
+                if tag.number() != self.1 {
+                    return Err(A::Error::custom(format!(
+                        "Expected Application number tag {} but got: {}",
+                        self.1,
+                        tag.number()
+                    )));
+                }
+
+                let rest: ApplicationTagInner<E> = seq
+                    .next_element()
+                    .map_err(|e| A::Error::custom(format!("Cannot deserialize application tag inner value: {:?}", e)))?
+                    .ok_or(A::Error::missing_field("ApplicationInnerValue"))?;
+
+                Ok(rest.0)
+            }
+        }
+
+        let inner = deserializer
+            .deserialize_enum("ApplicationTag", &["ApplicationTag"], Visitor::<V>::new(T))
+            .map_err(|e| D::Error::custom(e))?;
+
+        Ok(Self(inner))
+    }
+}
+
+impl<V: ser::Serialize + Debug + PartialEq, const T: u8> ser::Serialize for ApplicationTag<V, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        use serde::ser::Error;
+
+        let mut buff = Vec::new();
+        {
+            let mut s = crate::Serializer::new_to_byte_buf(&mut buff);
+            self.0
+                .serialize(&mut s)
+                .map_err(|e| S::Error::custom(format!("Cannot serialize Application tag inner value: {:?}", e)))?;
+        }
+
+        let mut res = vec![Tag::application_constructed(T).inner()];
+
+        Length::serialize(buff.len(), &mut res)
+            .map_err(|e| S::Error::custom(format!("Cannot serialize Length: {:?}", e)))?;
+        res.extend_from_slice(&buff);
+
+        Asn1RawDer(res).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::application_tag::ApplicationTag;
+    use picky_asn1::wrapper::Utf8StringAsn1;
+
+    #[test]
+    fn test_application_tag() {
+        let expected = vec![106, 13, 12, 11, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109];
+
+        let app_10: ApplicationTag<Utf8StringAsn1, 10> = crate::from_bytes(&expected).unwrap();
+        let app_10_raw = crate::to_vec(&app_10).unwrap();
+
+        assert_eq!(expected, app_10_raw);
+    }
+}

--- a/picky-asn1-der/src/application_tag.rs
+++ b/picky-asn1-der/src/application_tag.rs
@@ -39,6 +39,11 @@ impl<'de, V: de::Deserialize<'de> + Debug + PartialEq, const T: u8> de::Deserial
             where
                 A: SeqAccess<'de>,
             {
+                #[derive(Debug, serde::Deserialize)]
+                struct ApplicationTagInner<V: Debug> {
+                    value: V,
+                }
+
                 let tag_peeker: TagPeeker = seq
                     .next_element()
                     .map_err(|e| A::Error::custom(format!("Cannot deserialize application tag: {:?}", e)))?
@@ -58,11 +63,6 @@ impl<'de, V: de::Deserialize<'de> + Debug + PartialEq, const T: u8> de::Deserial
                         self.1,
                         tag.number()
                     )));
-                }
-
-                #[derive(Debug, serde::Deserialize)]
-                struct ApplicationTagInner<V: Debug> {
-                    value: V,
                 }
 
                 let rest: ApplicationTagInner<E> = seq

--- a/picky-asn1-der/src/de/mod.rs
+++ b/picky-asn1-der/src/de/mod.rs
@@ -186,6 +186,8 @@ impl<'de> Deserializer<'de> {
                         tag,
                         encapsulator_tag
                     );
+                    // we need to clear the stack otherwise it'll contain unwanted tags on the next serialization
+                    self.encapsulator_tag_stack.clear();
                     return Err(Asn1DerError::InvalidData);
                 }
 

--- a/picky-asn1-der/src/de/mod.rs
+++ b/picky-asn1-der/src/de/mod.rs
@@ -229,6 +229,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Tag::PRINTABLE_STRING => self.deserialize_byte_buf(visitor),
             Tag::NUMERIC_STRING => self.deserialize_byte_buf(visitor),
             Tag::IA5_STRING => self.deserialize_byte_buf(visitor),
+            Tag::GENERAL_STRING => self.deserialize_byte_buf(visitor),
             ExplicitContextTag0::<()>::TAG => self.deserialize_newtype_struct(ExplicitContextTag0::<()>::NAME, visitor),
             ExplicitContextTag1::<()>::TAG => self.deserialize_newtype_struct(ExplicitContextTag1::<()>::NAME, visitor),
             ExplicitContextTag2::<()>::TAG => self.deserialize_newtype_struct(ExplicitContextTag2::<()>::NAME, visitor),
@@ -498,6 +499,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Tag::PRINTABLE_STRING => {}
             Tag::NUMERIC_STRING => {}
             Tag::IA5_STRING => {}
+            Tag::GENERAL_STRING => {}
             tag if (tag.is_primitive() && !tag.is_universal()) || self.raw_der => {}
             _tag => {
                 debug_log!("deserialize_byte_buf: INVALID (found {})", _tag);

--- a/picky-asn1-der/src/lib.rs
+++ b/picky-asn1-der/src/lib.rs
@@ -72,8 +72,9 @@
 #[macro_use]
 mod debug_log;
 
+pub mod application_tag;
 mod de;
-mod misc;
+pub(crate) mod misc;
 mod raw_der;
 mod ser;
 

--- a/picky-asn1-der/src/misc.rs
+++ b/picky-asn1-der/src/misc.rs
@@ -18,7 +18,7 @@ impl<T: Read> ReadExt for T {
     }
 }
 /// An extension for `io::Write`
-pub trait WriteExt {
+pub(crate) trait WriteExt {
     /// Writes on `byte`
     fn write_one(&mut self, byte: u8) -> io::Result<usize>;
     /// Writes all bytes in `data`

--- a/picky-asn1-der/src/misc.rs
+++ b/picky-asn1-der/src/misc.rs
@@ -18,7 +18,7 @@ impl<T: Read> ReadExt for T {
     }
 }
 /// An extension for `io::Write`
-pub(crate) trait WriteExt {
+pub trait WriteExt {
     /// Writes on `byte`
     fn write_one(&mut self, byte: u8) -> io::Result<usize>;
     /// Writes all bytes in `data`

--- a/picky-asn1-der/src/ser/mod.rs
+++ b/picky-asn1-der/src/ser/mod.rs
@@ -284,6 +284,7 @@ impl<'a, 'se> serde::ser::Serializer for &'a mut Serializer<'se> {
             NumericStringAsn1::NAME => self.tag_for_next_bytes = Tag::NUMERIC_STRING,
             IA5StringAsn1::NAME => self.tag_for_next_bytes = Tag::IA5_STRING,
             BMPStringAsn1::NAME => self.tag_for_next_bytes = Tag::BMP_STRING,
+            GeneralStringAsn1::NAME => self.tag_for_next_bytes = Tag::GENERAL_STRING,
             Asn1SetOf::<()>::NAME => self.tag_for_next_seq = Tag::SET,
             Asn1SequenceOf::<()>::NAME => self.tag_for_next_seq = Tag::SEQUENCE,
             BitStringAsn1Container::<()>::NAME => self.h_encapsulate(Tag::BIT_STRING),

--- a/picky-asn1/src/tag.rs
+++ b/picky-asn1/src/tag.rs
@@ -58,6 +58,7 @@ impl Tag {
     pub const GENERALIZED_TIME: Self = Tag(0x18);
     pub const SEQUENCE: Self = Tag(0x30);
     pub const SET: Self = Tag(0x31);
+    pub const GENERAL_STRING: Self = Tag(0x1b);
 
     #[inline]
     pub const fn application_primitive(number: u8) -> Self {
@@ -180,6 +181,7 @@ impl fmt::Display for Tag {
             Tag::GENERALIZED_TIME => write!(f, "GeneralizedTime"),
             Tag::SEQUENCE => write!(f, "SEQUENCE"),
             Tag::SET => write!(f, "SET"),
+            Tag::GENERAL_STRING => write!(f, "GeneralString"),
             other => write!(f, "{}({:02X}) {}", other.class(), other.number(), other.encoding()),
         }
     }

--- a/picky-asn1/src/wrapper.rs
+++ b/picky-asn1/src/wrapper.rs
@@ -642,6 +642,12 @@ impls! { OctetStringAsn1Container<Encapsulated>, Tag::OCTET_STRING }
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone)]
 pub struct Optional<T>(pub T);
 
+impl<T: Default> Default for Optional<T> {
+    fn default() -> Self {
+        Optional(T::default())
+    }
+}
+
 impl<T> Optional<T>
 where
     T: Default + PartialEq,

--- a/picky-asn1/src/wrapper.rs
+++ b/picky-asn1/src/wrapper.rs
@@ -200,6 +200,11 @@ asn1_wrapper! { auto struct IA5StringAsn1(IA5String),               Tag::IA5_STR
 asn1_wrapper! { auto struct BMPStringAsn1(BMPString),               Tag::BMP_STRING }
 asn1_wrapper! { auto struct UTCTimeAsn1(UTCTime),                   Tag::UTC_TIME }
 asn1_wrapper! { auto struct GeneralizedTimeAsn1(GeneralizedTime),   Tag::GENERALIZED_TIME }
+// [RFC 4120 5.2.1](https://www.rfc-editor.org/rfc/rfc4120.txt)
+// Kerberos specification declares General String as IA5String
+// ```not-rust
+// KerberosString  ::= GeneralString (IA5String)
+// ```
 asn1_wrapper! { auto struct GeneralStringAsn1(IA5String),           Tag::GENERAL_STRING }
 
 asn1_wrapper! { auto collection struct Asn1SequenceOf<T>, Tag::SEQUENCE }

--- a/picky-asn1/src/wrapper.rs
+++ b/picky-asn1/src/wrapper.rs
@@ -200,6 +200,7 @@ asn1_wrapper! { auto struct IA5StringAsn1(IA5String),               Tag::IA5_STR
 asn1_wrapper! { auto struct BMPStringAsn1(BMPString),               Tag::BMP_STRING }
 asn1_wrapper! { auto struct UTCTimeAsn1(UTCTime),                   Tag::UTC_TIME }
 asn1_wrapper! { auto struct GeneralizedTimeAsn1(GeneralizedTime),   Tag::GENERALIZED_TIME }
+asn1_wrapper! { auto struct GeneralStringAsn1(IA5String),           Tag::GENERAL_STRING }
 
 asn1_wrapper! { auto collection struct Asn1SequenceOf<T>, Tag::SEQUENCE }
 asn1_wrapper! { auto collection struct Asn1SetOf<T>,      Tag::SET }


### PR DESCRIPTION
KDC proxy in DG related improvements:
- Added `ApplicationTag<V, const T: u8>` for easier using needed `ApplicationTagN` without adding a lot of new `ApplicationTag`s.
- Added `GENERAL_STRING`.
- Added `impl<T: Default> Default for Optional<T>`.
- Added clearing `encapsulator_tag_stack` as otherwise, it would contain unwanted tags on the next serialization.