### PR TITLE
Handle verification of keys using elliptic curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "reqwest 0.11.7",
  "ring",
  "rsa",
+ "rstest",
  "serde",
  "serde_json",
  "sha-1",
@@ -2631,6 +2632,19 @@ dependencies = [
  "rand 0.8.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -52,12 +52,14 @@ aes-gcm = { version = "0.9.4", optional = true }
 bcrypt-pbkdf = { version = "0.6", optional = true }
 block-modes = { version = "0.8", optional = true }
 aes = { version = "0.7.5", features = ["ctr"], default-features = false, optional = true }
+ring = "0.16.20"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 hex = "0.4.3"
 cfg-if = "1.0.0"
 ring = "0.16.20"
+rstest = "0.12.0"
 
 [features]
 default = ["x509", "jose", "http_signature", "http_trait_impl"]

--- a/picky/src/http/http_signature.rs
+++ b/picky/src/http/http_signature.rs
@@ -829,6 +829,9 @@ const HTTP_SIG_ALGO_RSA_SHA2_512: &str = "rsa-sha2-512";
 const HTTP_SIG_ALGO_RSA_SHA3_384: &str = "rsa-sha3-384";
 const HTTP_SIG_ALGO_RSA_SHA3_512: &str = "rsa-sha3-512";
 
+const HTTP_SIG_ALGO_ECDSA_SHA_256: &str = "ecdsa-sha256";
+const HTTP_SIG_ALGO_ECDSA_SHA_384: &str = "ecdsa-sha384";
+
 fn to_http_sig_algo_str(algo: SignatureAlgorithm) -> &'static str {
     match algo {
         SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::MD5) => HTTP_SIG_ALGO_RSA_MD5,
@@ -839,6 +842,9 @@ fn to_http_sig_algo_str(algo: SignatureAlgorithm) -> &'static str {
         SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA2_512) => HTTP_SIG_ALGO_RSA_SHA_512,
         SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_384) => HTTP_SIG_ALGO_RSA_SHA3_384,
         SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_512) => HTTP_SIG_ALGO_RSA_SHA3_512,
+        SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_256) => HTTP_SIG_ALGO_ECDSA_SHA_256,
+        SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_384) => HTTP_SIG_ALGO_ECDSA_SHA_384,
+        SignatureAlgorithm::Ecdsa(_) => "ECDSA unsupported algorithm",
     }
 }
 
@@ -860,6 +866,8 @@ fn from_http_sig_algo_str(s: &str) -> Option<SignatureAlgorithm> {
         }
         HTTP_SIG_ALGO_RSA_SHA3_384 => Some(SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_384)),
         HTTP_SIG_ALGO_RSA_SHA3_512 => Some(SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_512)),
+        HTTP_SIG_ALGO_ECDSA_SHA_256 => Some(SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_256)),
+        HTTP_SIG_ALGO_ECDSA_SHA_384 => Some(SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_384)),
         _ => None,
     }
 }

--- a/picky/src/key.rs
+++ b/picky/src/key.rs
@@ -2,9 +2,9 @@
 
 use crate::pem::{parse_pem, Pem, PemError};
 use num_bigint_dig::traits::ModInverse;
-use picky_asn1::wrapper::{BitStringAsn1Container, IntegerAsn1, OctetStringAsn1Container};
+use picky_asn1::wrapper::{BitStringAsn1, BitStringAsn1Container, IntegerAsn1, OctetStringAsn1Container};
 use picky_asn1_der::Asn1DerError;
-use picky_asn1_x509::{private_key_info, PrivateKeyInfo, PrivateKeyValue, SubjectPublicKeyInfo};
+use picky_asn1_x509::{oids, private_key_info, PrivateKeyInfo, PrivateKeyValue, SubjectPublicKeyInfo};
 use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
 use thiserror::Error;
 
@@ -123,6 +123,70 @@ impl TryFrom<&'_ PrivateKey> for RsaPublicKey {
             private_key_info::PrivateKeyValue::EC(_) => Err(KeyError::Rsa {
                 context: "RSA public key cannot be constructed from an EC private key.".to_string(),
             }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EcdsaKeypair<'a> {
+    pub(crate) private_key: Vec<u8>,
+    pub(crate) public_key: &'a [u8],
+    pub(crate) curve: EcdsaCurve,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum EcdsaCurve {
+    Nist256,
+    Nist384,
+    Nist512,
+}
+
+impl<'a> TryFrom<&'a PrivateKey> for EcdsaKeypair<'a> {
+    type Error = KeyError;
+
+    fn try_from(v: &'a PrivateKey) -> Result<Self, Self::Error> {
+        match &v.as_inner().private_key {
+            private_key_info::PrivateKeyValue::RSA(_) => Err(KeyError::EC {
+                context: "EC keypair cannot be built from RSA private key".to_string(),
+            }),
+            private_key_info::PrivateKeyValue::EC(OctetStringAsn1Container(private_key)) => {
+                let private_key_data = private_key.private_key.to_vec();
+                let public_key_data = private_key.public_key.payload_view();
+
+                let curve = match &private_key.parameters.0 .0 {
+                    Some(ec_parameters) => match ec_parameters {
+                        picky_asn1_x509::EcParameters::NamedCurve(curve) => {
+                            let oid = Into::<String>::into(&curve.0);
+                            match oid.as_str() {
+                                oids::SECP256R1 => Ok(EcdsaCurve::Nist256),
+                                oids::SECP384R1 => Ok(EcdsaCurve::Nist384),
+                                oids::SECP521R1 => Ok(EcdsaCurve::Nist512),
+                                unknown => Err(KeyError::EC {
+                                    context: format!("Unknown curve type: {}", unknown),
+                                }),
+                            }
+                        }
+                    },
+                    None => Err(KeyError::EC {
+                        context: "EC keypair cannot be built when curve type is not provided by private key"
+                            .to_string(),
+                    }),
+                }?;
+
+                if public_key_data.is_empty() {
+                    Err(KeyError::EC {
+                        context:
+                            "EC keypair cannot be built from EC private key that doesn't have a bundled private key"
+                                .to_string(),
+                    })
+                } else {
+                    Ok(EcdsaKeypair {
+                        private_key: private_key_data,
+                        public_key: public_key_data,
+                        curve,
+                    })
+                }
+            }
         }
     }
 }
@@ -356,6 +420,31 @@ impl TryFrom<&'_ PublicKey> for RsaPublicKey {
     }
 }
 
+pub(crate) struct EcdsaPublicKey<'a> {
+    pub(crate) data: &'a [u8],
+}
+
+impl<'a> TryFrom<&'a PublicKey> for EcdsaPublicKey<'a> {
+    type Error = KeyError;
+
+    fn try_from(v: &'a PublicKey) -> Result<Self, Self::Error> {
+        use picky_asn1_x509::PublicKey as InnerPublicKey;
+
+        match &v.as_inner().subject_public_key {
+            InnerPublicKey::Rsa(_) => Err(KeyError::EC {
+                context: "EC public key cannot be constructed from RSA public key".to_string(),
+            }),
+            InnerPublicKey::Ec(BitStringAsn1(bitstring)) => {
+                let data = bitstring.payload_view();
+                Ok(EcdsaPublicKey { data })
+            }
+            InnerPublicKey::Ed(_) => Err(KeyError::EC {
+                context: "EC public key cannot be constructed from ED25519 public key".to_string(),
+            }),
+        }
+    }
+}
+
 impl PublicKey {
     pub fn from_rsa_components(modulus: &BigUint, public_exponent: &BigUint) -> Self {
         PublicKey(SubjectPublicKeyInfo::new_rsa_key(
@@ -430,6 +519,7 @@ mod tests {
     use crate::hash::HashAlgorithm;
     use crate::signature::SignatureAlgorithm;
     use rsa::PublicKeyParts;
+    use rstest::*;
 
     cfg_if::cfg_if! { if #[cfg(feature = "x509")] {
         use crate::x509::{certificate::CertificateBuilder, date::UtcDate, name::DirectoryName};
@@ -581,14 +671,6 @@ mod tests {
         ring::signature::RsaKeyPair::from_pkcs8(&pkcs8).unwrap();
     }
 
-    const EC_PRIVATE_KEY_PEM: &str = "-----BEGIN EC PRIVATE KEY-----\n\
-                                      MIHcAgEBBEIBhqphIGu2PmlcEb6xADhhSCpgPUulB0s4L2qOgolRgaBx4fNgINFE\n\
-                                      mBsSyHJncsWG8WFEuUzAYy/YKz2lP0Qx6Z2gBwYFK4EEACOhgYkDgYYABABwBevJ\n\
-                                      w/+Xh6I98ruzoTX3MNTsbgnc+glenJRCbEJkjbJrObFhbfgqP52r1lAy2RxuShGi\n\
-                                      NYJJzNPT6vR1abS32QFtvTH7YbYa6OWk9dtGNY/cYxgx1nQyhUuofdW7qbbfu/Ww\n\
-                                      TP2oFsPXRAavZCh4AbWUn8bAHmzNRyuJonQBKlQlVQ==\n\
-                                      -----END EC PRIVATE KEY-----";
-
     const PKCS8_EC_PRIVATE_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\n\
                                             MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgKZqrmOg/cDZ4tPCn\n\
                                             4LROs145nxx+ssufvflL8cROxFmhRANCAARmU90fCSTsncefY7hVeKw1WIg/YQmT\n\
@@ -600,18 +682,64 @@ mod tests {
                                     bJM105PImXUuqTMyqSmX96/m7zFfyh/DQQbyXIo3E07qifCPMw9/oQ==\n\
                                     -----END PUBLIC KEY-----";
 
-    #[test]
-    fn private_key_from_ec_pem() {
-        PrivateKey::from_pem_str(EC_PRIVATE_KEY_PEM).unwrap();
-    }
+    const EC_PRIVATE_KEY_NIST256_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICHio5XUa+RbeFfGtGHfbPWehTFJJtCB4/izKHJ9Vm+goAoGCCqGSM49
+AwEHoUQDQgAEh7ZqcI6f0tgqq7nqdcxWM6P4GGCfkWc4q11uXFjtXOKHKCV3LzMY
+g8/V1PD/YOh0HodRJAjkjXub8AmYxiTcXw==
+-----END EC PRIVATE KEY-----"#;
 
-    #[test]
-    fn private_key_from_pkcs8_ec_pem() {
-        PrivateKey::from_pem_str(PKCS8_EC_PRIVATE_KEY_PEM).unwrap();
+    const EC_PRIVATE_KEY_NIST384_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDDT8VOfdzHbIRaWOO1F0vgotY2qM2FfYS3zpdKE7Vqbh26hFsUw+iaG
+GmGnT+29kg+gBwYFK4EEACKhZANiAAQFvVVUKRdN3/bqaEpDA1aHu8FEd3ujuyS0
+AadG6QAiZxH37BGumBcyTTeGHyArqb+GTpsHTUXASbP+P+p5JgkfF9wBMF1SVTvu
+ACZOYcqzGbsAXXdMYqewckhc42ye0u0=
+-----END EC PRIVATE KEY-----"#;
+
+    const EC_PRIVATE_KEY_NIST512_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MIHcAgEBBEIBhqphIGu2PmlcEb6xADhhSCpgPUulB0s4L2qOgolRgaBx4fNgINFE
+mBsSyHJncsWG8WFEuUzAYy/YKz2lP0Qx6Z2gBwYFK4EEACOhgYkDgYYABABwBevJ
+w/+Xh6I98ruzoTX3MNTsbgnc+glenJRCbEJkjbJrObFhbfgqP52r1lAy2RxuShGi
+NYJJzNPT6vR1abS32QFtvTH7YbYa6OWk9dtGNY/cYxgx1nQyhUuofdW7qbbfu/Ww
+TP2oFsPXRAavZCh4AbWUn8bAHmzNRyuJonQBKlQlVQ==
+-----END EC PRIVATE KEY-----"#;
+
+    #[rstest]
+    #[case(EC_PRIVATE_KEY_NIST256_PEM)]
+    #[case(EC_PRIVATE_KEY_NIST384_PEM)]
+    #[case(EC_PRIVATE_KEY_NIST512_PEM)]
+    #[case(PKCS8_EC_PRIVATE_KEY_PEM)]
+    fn private_key_from_ec_pem(#[case] key_pem: &str) {
+        PrivateKey::from_pem_str(key_pem).unwrap();
     }
 
     #[test]
     fn public_key_from_ec_pem() {
         PublicKey::from_pem_str(EC_PUBLIC_KEY_PEM).unwrap();
+    }
+
+    #[test]
+    fn ecdsa_public_key_conversions() {
+        // ECDSA public key conversion works
+        let pk: &PublicKey = &PublicKey::from_pem_str(EC_PUBLIC_KEY_PEM).unwrap();
+        let epk: Result<EcdsaPublicKey, KeyError> = pk.try_into();
+        assert!(epk.is_ok());
+
+        // PEM public key conversion fails with an error
+        let pk: &PublicKey = &PublicKey::from_pem_str(RSA_PUBLIC_KEY_PEM).unwrap();
+        let epk: Result<EcdsaPublicKey, KeyError> = pk.try_into();
+        assert!(epk.is_err());
+        assert!(matches!(epk, Err(KeyError::EC { context: _ })));
+
+        // TODO: add check for attempted conversion from ED keys - which are not supported yet
+    }
+
+    #[rstest]
+    #[case(EC_PRIVATE_KEY_NIST256_PEM, EcdsaCurve::Nist256)]
+    #[case(EC_PRIVATE_KEY_NIST384_PEM, EcdsaCurve::Nist384)]
+    #[case(EC_PRIVATE_KEY_NIST512_PEM, EcdsaCurve::Nist512)]
+    fn ecdsa_key_pair_from_ec_private_key(#[case] key: &str, #[case] curve: EcdsaCurve) {
+        let pk = PrivateKey::from_pem_str(key).unwrap();
+        let pair = EcdsaKeypair::try_from(&pk).unwrap();
+        assert_eq!(curve, pair.curve);
     }
 }

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -1,7 +1,7 @@
 //! Signature algorithms supported by picky
 
 use crate::hash::HashAlgorithm;
-use crate::key::{KeyError, PrivateKey, PublicKey};
+use crate::key::{EcdsaCurve, EcdsaKeypair, EcdsaPublicKey, KeyError, PrivateKey, PublicKey};
 use picky_asn1_x509::{oids, AlgorithmIdentifier};
 use rsa::{PublicKey as _, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
@@ -17,6 +17,10 @@ pub enum SignatureError {
     /// RSA error
     #[error("RSA error: {context}")]
     Rsa { context: String },
+
+    /// EC error
+    #[error("EC error: {context}")]
+    Ec { context: String },
 
     /// invalid signature
     #[error("invalid signature")]
@@ -44,6 +48,7 @@ impl From<KeyError> for SignatureError {
 #[non_exhaustive]
 pub enum SignatureAlgorithm {
     RsaPkcs1v15(HashAlgorithm),
+    Ecdsa(HashAlgorithm),
 }
 
 impl TryFrom<&'_ AlgorithmIdentifier> for SignatureAlgorithm {
@@ -60,33 +65,48 @@ impl TryFrom<&'_ AlgorithmIdentifier> for SignatureAlgorithm {
             oids::SHA512_WITH_RSA_ENCRYPTION => Ok(Self::RsaPkcs1v15(HashAlgorithm::SHA2_512)),
             oids::ID_RSASSA_PKCS1_V1_5_WITH_SHA3_384 => Ok(Self::RsaPkcs1v15(HashAlgorithm::SHA3_384)),
             oids::ID_RSASSA_PKCS1_V1_5_WITH_SHA3_512 => Ok(Self::RsaPkcs1v15(HashAlgorithm::SHA3_512)),
+            oids::ECDSA_WITH_SHA256 => Ok(Self::Ecdsa(HashAlgorithm::SHA2_256)),
+            oids::ECDSA_WITH_SHA384 => Ok(Self::Ecdsa(HashAlgorithm::SHA2_384)),
             _ => Err(SignatureError::UnsupportedAlgorithm { algorithm: oid_string }),
         }
     }
 }
 
-impl From<SignatureAlgorithm> for AlgorithmIdentifier {
-    fn from(ty: SignatureAlgorithm) -> Self {
+impl TryFrom<SignatureAlgorithm> for AlgorithmIdentifier {
+    type Error = SignatureError;
+
+    fn try_from(ty: SignatureAlgorithm) -> Result<Self, Self::Error> {
         match ty {
-            SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::MD5) => AlgorithmIdentifier::new_md5_with_rsa_encryption(),
-            SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA1) => AlgorithmIdentifier::new_sha1_with_rsa_encryption(),
+            SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::MD5) => {
+                Ok(AlgorithmIdentifier::new_md5_with_rsa_encryption())
+            }
+            SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA1) => {
+                Ok(AlgorithmIdentifier::new_sha1_with_rsa_encryption())
+            }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA2_224) => {
-                AlgorithmIdentifier::new_sha224_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha224_with_rsa_encryption())
             }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA2_256) => {
-                AlgorithmIdentifier::new_sha256_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha256_with_rsa_encryption())
             }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA2_384) => {
-                AlgorithmIdentifier::new_sha384_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha384_with_rsa_encryption())
             }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA2_512) => {
-                AlgorithmIdentifier::new_sha512_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha512_with_rsa_encryption())
             }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_384) => {
-                AlgorithmIdentifier::new_sha3_384_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha3_384_with_rsa_encryption())
             }
             SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA3_512) => {
-                AlgorithmIdentifier::new_sha3_512_with_rsa_encryption()
+                Ok(AlgorithmIdentifier::new_sha3_512_with_rsa_encryption())
+            }
+            SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_256) => Ok(AlgorithmIdentifier::new_ecdsa_with_sha256()),
+            SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_384) => Ok(AlgorithmIdentifier::new_ecdsa_with_sha384()),
+            SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_512) => Ok(AlgorithmIdentifier::new_ecdsa_with_sha512()),
+            SignatureAlgorithm::Ecdsa(hash) => {
+                let msg = format!("ECDSA doesn't support {:?} hashing algorithm", hash);
+                Err(SignatureError::Ec { context: msg })
             }
         }
     }
@@ -106,6 +126,48 @@ impl SignatureAlgorithm {
                 let padding_scheme = rsa::PaddingScheme::new_pkcs1v15_sign(Some(rsa_hash_algo));
                 rsa_private_key.sign_blinded(&mut rand::rngs::OsRng, padding_scheme, &digest)?
             }
+            SignatureAlgorithm::Ecdsa(picky_hash_algo) => {
+                let ec_keypair = EcdsaKeypair::try_from(private_key)?;
+
+                let signing_algorithm = match ec_keypair.curve {
+                    EcdsaCurve::Nist256 => match picky_hash_algo {
+                        HashAlgorithm::SHA2_256 => Ok(&ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING),
+                        _ => Err(SignatureError::UnsupportedAlgorithm {
+                            algorithm: format!(
+                                "ECDSA P-256 curve with {:?} hash algorithm is not supported",
+                                picky_hash_algo
+                            ),
+                        }),
+                    },
+                    EcdsaCurve::Nist384 => match picky_hash_algo {
+                        HashAlgorithm::SHA2_384 => Ok(&ring::signature::ECDSA_P384_SHA384_ASN1_SIGNING),
+                        _ => Err(SignatureError::UnsupportedAlgorithm {
+                            algorithm: format!(
+                                "ECDSA P-384 curve with {:?} hash algorithm is not supported",
+                                picky_hash_algo
+                            ),
+                        }),
+                    },
+                    EcdsaCurve::Nist512 => Err(SignatureError::UnsupportedAlgorithm {
+                        algorithm: "ECDSA P-512 curve is not yet supported".to_string(),
+                    }),
+                }?;
+
+                let keypair = ring::signature::EcdsaKeyPair::from_private_key_and_public_key(
+                    signing_algorithm,
+                    &ec_keypair.private_key,
+                    ec_keypair.public_key,
+                )
+                .map_err(|e| SignatureError::Ec {
+                    context: format!("Cannot decode EC keypair: {}", e),
+                })?;
+
+                let rng = ring::rand::SystemRandom::new();
+                let signature = keypair.sign(&rng, msg).map_err(|e| SignatureError::Ec {
+                    context: format!("Cannot produce signature: {}", e),
+                })?;
+                signature.as_ref().to_vec()
+            }
         };
 
         Ok(signature)
@@ -122,6 +184,22 @@ impl SignatureAlgorithm {
                     .verify(padding_scheme, &digest, signature)
                     .map_err(|_| SignatureError::BadSignature)?;
             }
+            SignatureAlgorithm::Ecdsa(picky_hash_algo) => {
+                let verification_algorithm = match picky_hash_algo {
+                    HashAlgorithm::SHA2_256 => Ok(&ring::signature::ECDSA_P256_SHA256_ASN1),
+                    HashAlgorithm::SHA2_384 => Ok(&ring::signature::ECDSA_P384_SHA384_ASN1),
+                    _ => Err(SignatureError::UnsupportedAlgorithm {
+                        algorithm: format!("ECDSA with {:?} hash algorithm is not supported", picky_hash_algo),
+                    }),
+                }?;
+
+                let ec_pub_key = EcdsaPublicKey::try_from(public_key)?;
+                let verification_key = ring::signature::UnparsedPublicKey::new(verification_algorithm, ec_pub_key.data);
+
+                verification_key
+                    .verify(msg, signature)
+                    .map_err(|_| SignatureError::BadSignature)?
+            }
         }
 
         Ok(())
@@ -130,6 +208,97 @@ impl SignatureAlgorithm {
     pub fn hash_algorithm(&self) -> HashAlgorithm {
         match &self {
             SignatureAlgorithm::RsaPkcs1v15(hash_algo) => *hash_algo,
+            SignatureAlgorithm::Ecdsa(hash_algo) => *hash_algo,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    const EC_PRIVATE_KEY_NIST256_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICHio5XUa+RbeFfGtGHfbPWehTFJJtCB4/izKHJ9Vm+goAoGCCqGSM49
+AwEHoUQDQgAEh7ZqcI6f0tgqq7nqdcxWM6P4GGCfkWc4q11uXFjtXOKHKCV3LzMY
+g8/V1PD/YOh0HodRJAjkjXub8AmYxiTcXw==
+-----END EC PRIVATE KEY-----"#;
+
+    const EC_PRIVATE_KEY_NIST384_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDDT8VOfdzHbIRaWOO1F0vgotY2qM2FfYS3zpdKE7Vqbh26hFsUw+iaG
+GmGnT+29kg+gBwYFK4EEACKhZANiAAQFvVVUKRdN3/bqaEpDA1aHu8FEd3ujuyS0
+AadG6QAiZxH37BGumBcyTTeGHyArqb+GTpsHTUXASbP+P+p5JgkfF9wBMF1SVTvu
+ACZOYcqzGbsAXXdMYqewckhc42ye0u0=
+-----END EC PRIVATE KEY-----"#;
+
+    const EC_PRIVATE_KEY_NIST512_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
+MIHcAgEBBEIBhqphIGu2PmlcEb6xADhhSCpgPUulB0s4L2qOgolRgaBx4fNgINFE
+mBsSyHJncsWG8WFEuUzAYy/YKz2lP0Qx6Z2gBwYFK4EEACOhgYkDgYYABABwBevJ
+w/+Xh6I98ruzoTX3MNTsbgnc+glenJRCbEJkjbJrObFhbfgqP52r1lAy2RxuShGi
+NYJJzNPT6vR1abS32QFtvTH7YbYa6OWk9dtGNY/cYxgx1nQyhUuofdW7qbbfu/Ww
+TP2oFsPXRAavZCh4AbWUn8bAHmzNRyuJonQBKlQlVQ==
+-----END EC PRIVATE KEY-----"#;
+
+    #[rstest]
+    #[case(HashAlgorithm::MD5, false)]
+    #[case(HashAlgorithm::SHA1, false)]
+    #[case(HashAlgorithm::SHA2_224, false)]
+    #[case(HashAlgorithm::SHA2_256, true)]
+    #[case(HashAlgorithm::SHA2_384, true)]
+    #[case(HashAlgorithm::SHA2_512, true)]
+    #[case(HashAlgorithm::SHA3_384, false)]
+    #[case(HashAlgorithm::SHA3_512, false)]
+    fn ec_algorithm_identifier_conversions(#[case] hash: HashAlgorithm, #[case] success: bool) {
+        let signature_algorithm = SignatureAlgorithm::Ecdsa(hash);
+        let algorithm_identifier = AlgorithmIdentifier::try_from(signature_algorithm);
+        if success {
+            assert!(algorithm_identifier.is_ok());
+        } else {
+            assert!(matches!(algorithm_identifier, Err(SignatureError::Ec { context: _ })));
+        }
+    }
+
+    #[test]
+    fn ec_verify_bad_signature() {
+        let private_key_signature = PrivateKey::from_pem_str(EC_PRIVATE_KEY_NIST256_PEM).unwrap();
+        let signature_algorithm = SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_256);
+
+        let msg = b"hello world";
+        let signature = signature_algorithm.sign(msg, &private_key_signature).unwrap();
+
+        let another_ec_private_key_nist256_pem = r#"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBVYtZ17YMj89Kuu47TOxJlLVlk7MDUuAlFrVXxexgkSoAoGCCqGSM49
+AwEHoUQDQgAE/irzdOJk28zjVv3sov15/NLIOxoIwL9kM2p/RfQAslATwHpD/T79
+csaQwO9jFvbQFIpCvcMRjaunLfhIWiYDdg==
+-----END EC PRIVATE KEY-----"#;
+
+        let another_private_key = PrivateKey::from_pem_str(another_ec_private_key_nist256_pem).unwrap();
+        let wrong_public_key = PublicKey::from(another_private_key);
+        assert!(matches!(
+            signature_algorithm.verify(&wrong_public_key, msg, &signature),
+            Err(SignatureError::BadSignature)
+        ));
+    }
+
+    #[rstest]
+    #[case(EC_PRIVATE_KEY_NIST256_PEM, HashAlgorithm::SHA2_256, true)]
+    #[case(EC_PRIVATE_KEY_NIST384_PEM, HashAlgorithm::SHA2_384, true)]
+    #[case(EC_PRIVATE_KEY_NIST512_PEM, HashAlgorithm::SHA2_512, false)] // EC Nist 512 is not supported by ring yet
+    fn ec_sign_and_verify(#[case] key_pem: &str, #[case] hash: HashAlgorithm, #[case] sign_successful: bool) {
+        let private_key = PrivateKey::from_pem_str(key_pem).unwrap();
+        let signature_algorithm = SignatureAlgorithm::Ecdsa(hash);
+
+        let msg = b"hello world";
+        let signature = signature_algorithm.sign(msg, &private_key);
+        assert_eq!(signature.is_ok(), sign_successful);
+
+        if !sign_successful {
+            return;
+        }
+
+        let public_key = PublicKey::from(private_key);
+        signature_algorithm
+            .verify(&public_key, msg, &signature.unwrap())
+            .unwrap();
     }
 }

--- a/picky/src/ssh/certificate.rs
+++ b/picky/src/ssh/certificate.rs
@@ -630,6 +630,11 @@ impl SshCertificateBuilder {
                             )))
                         }
                     },
+                    SignatureAlgorithm::Ecdsa(_) => {
+                        return Err(SshCertificateGenerationError::IncorrectSignatureAlgorithm(
+                            "Ecdsa signatures for SSH certificates are not yet supported".to_owned(),
+                        ))
+                    }
                 };
 
                 let signature = signature_algo.sign(&raw_signature, rsa)?;

--- a/picky/src/x509/csr.rs
+++ b/picky/src/x509/csr.rs
@@ -159,9 +159,13 @@ fn h_generate_from_cri(
             .map_err(|e| CsrError::Signature { source: e })?,
     );
 
+    let signature_algorithm = signature_hash_type
+        .try_into()
+        .map_err(|e| CsrError::Signature { source: e })?;
+
     Ok(Csr(CertificationRequest {
         certification_request_info: cri,
-        signature_algorithm: signature_hash_type.into(),
+        signature_algorithm,
         signature: signature.into(),
     }))
 }


### PR DESCRIPTION
This PR introduces support for handling certificates using elliptic curve public keys.

~~Only signature verification is currently implemented.~~
**Update:** Both signature creation and verification are supported.

The implementation relies on the `ring` crate, which currently is the only one capable of supporting both ECDSA p256 and ECDSA p384.

~~I haven't yet extended the unit tests. I'm looking forward to hear your feedback about this contribution. I think this is something you're interested about (see #100). I wonder if this is going in the direction you like.~~
**Update:** The unit tests have been extended too

