### PR TITLE
Release chores (picky-asn1-x509 0.7.0 and picky 7.0.0-rc.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
  "oid",
  "picky-asn1 0.5.0",
  "picky-asn1-der 0.3.0",
- "picky-asn1-x509 0.6.1",
+ "picky-asn1-x509 0.7.0",
  "pretty_assertions",
  "rand 0.8.4",
  "reqwest 0.11.7",
@@ -2018,7 +2018,7 @@ dependencies = [
  "oid",
  "picky-asn1 0.4.0",
  "picky-asn1-der 0.2.5",
- "picky-asn1-x509 0.6.1 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
+ "picky-asn1-x509 0.6.1",
  "rand 0.8.4",
  "rsa",
  "serde",
@@ -2078,6 +2078,20 @@ dependencies = [
 [[package]]
 name = "picky-asn1-x509"
 version = "0.6.1"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
+dependencies = [
+ "base64 0.13.0",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1 0.4.0",
+ "picky-asn1-der 0.2.5",
+ "serde",
+ "widestring 0.4.3",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.7.0"
 dependencies = [
  "base64 0.13.0",
  "hex",
@@ -2088,20 +2102,6 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "widestring 0.5.1",
-]
-
-[[package]]
-name = "picky-asn1-x509"
-version = "0.6.1"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
-dependencies = [
- "base64 0.13.0",
- "num-bigint-dig",
- "oid",
- "picky-asn1 0.4.0",
- "picky-asn1-der 0.2.5",
- "serde",
- "widestring 0.4.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
  "bitflags",
  "image",
  "lief-sys",
- "picky 6.4.0 (git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1)",
+ "picky 6.4.0",
  "thiserror",
  "widestring 0.4.3",
 ]
@@ -1968,6 +1968,32 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "picky"
 version = "6.4.0"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
+dependencies = [
+ "aes-gcm",
+ "base64 0.13.0",
+ "byteorder",
+ "digest",
+ "http",
+ "md-5",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1 0.4.0",
+ "picky-asn1-der 0.2.5",
+ "picky-asn1-x509 0.6.1",
+ "rand 0.8.4",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "picky"
+version = "7.0.0-rc.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2001,32 +2027,6 @@ dependencies = [
  "sha3",
  "thiserror",
  "time 0.3.5",
-]
-
-[[package]]
-name = "picky"
-version = "6.4.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?rev=a0a0d1#a0a0d1216d86aa46693e0e78b137a233db2f872f"
-dependencies = [
- "aes-gcm",
- "base64 0.13.0",
- "byteorder",
- "digest",
- "http",
- "md-5",
- "num-bigint-dig",
- "oid",
- "picky-asn1 0.4.0",
- "picky-asn1-der 0.2.5",
- "picky-asn1-x509 0.6.1",
- "rand 0.8.4",
- "rsa",
- "serde",
- "serde_json",
- "sha-1",
- "sha2",
- "sha3",
- "thiserror",
 ]
 
 [[package]]
@@ -2112,7 +2112,7 @@ dependencies = [
  "diplomat-runtime",
  "embed-resource",
  "hex",
- "picky 6.4.0",
+ "picky 7.0.0-rc.1",
  "time 0.3.5",
 ]
 
@@ -2130,7 +2130,7 @@ dependencies = [
  "mongodm",
  "multibase",
  "multihash",
- "picky 6.4.0",
+ "picky 7.0.0-rc.1",
  "picky-asn1 0.5.0",
  "rand 0.8.4",
  "reqwest 0.11.7",
@@ -2154,7 +2154,7 @@ dependencies = [
  "clap",
  "encoding_rs",
  "lief-rs",
- "picky 6.4.0",
+ "picky 7.0.0-rc.1",
  "walkdir",
 ]
 

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -2,6 +2,7 @@
 name = "picky-asn1-der"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.56"
 authors = [
     "KizzyCode Software Labs./Keziah Biermann <development@kizzycode.de>",
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",

--- a/picky-asn1-der/README.md
+++ b/picky-asn1-der/README.md
@@ -2,7 +2,7 @@
 [![docs.rs](https://docs.rs/picky-asn1-der/badge.svg)](https://docs.rs/picky-asn1-der)
 ![Crates.io](https://img.shields.io/crates/l/picky-asn1-der)
 
-Compatible with rustc 1.43.
+Compatible with rustc 1.56.
 Minimal rustc version bumps happen [only with minor number bumps in this project](https://github.com/Devolutions/picky-rs/issues/89#issuecomment-868303478).
 
 # picky-asn1-der

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.7.0] 2022-03-04
+
 ### Added
 
 - Support for Authenticode timestamp deserialization/serialization

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-x509"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Sergey Noskov <snoskov@avito.ru>",

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 description = "Provides ASN1 types defined by X.509 related RFCs"
 edition = "2021"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 

--- a/picky-asn1-x509/README.md
+++ b/picky-asn1-x509/README.md
@@ -2,7 +2,7 @@
 [![docs.rs](https://docs.rs/picky-asn1-x509/badge.svg)](https://docs.rs/picky-asn1-x509)
 ![Crates.io](https://img.shields.io/crates/l/picky-asn1-x509)
 
-Compatible with rustc 1.43.
+Compatible with rustc 1.56.
 Minimal rustc version bumps happen [only with minor number bumps in this project](https://github.com/Devolutions/picky-rs/issues/89#issuecomment-868303478).
 
 # picky-asn1-x509

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -2,6 +2,7 @@
 name = "picky-asn1"
 version = "0.5.0"
 edition = "2021"
+rust-version = "1.56"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>",

--- a/picky-asn1/README.md
+++ b/picky-asn1/README.md
@@ -2,7 +2,7 @@
 [![docs.rs](https://docs.rs/picky-asn1/badge.svg)](https://docs.rs/picky-asn1)
 ![Crates.io](https://img.shields.io/crates/l/picky-asn1)
 
-Compatible with rustc 1.43.
+Compatible with rustc 1.56.
 Minimal rustc version bumps happen [only with minor number bumps in this project](https://github.com/Devolutions/picky-rs/issues/89#issuecomment-868303478).
 
 # picky-asn1

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
+publish = false
 
 [dependencies]
 picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "pkcs7", "ssh", "time_conversion" ], path = "../picky" }

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Devolutions/picky-rs"
 publish = false
 
 [dependencies]
-picky = { version = "6.4.0", default-features = false, features = ["x509", "jose", "pkcs7", "ssh", "time_conversion" ], path = "../picky" }
+picky = { version = "7.0.0-rc.1", default-features = false, features = ["x509", "jose", "pkcs7", "ssh", "time_conversion" ], path = "../picky" }
 picky-asn1 = { version = "0.5", path = "../picky-asn1" }
 mongodm = { version = "0.7.3", features = ["tokio-runtime"] }
 clap = { features = ["yaml"], version = "2.33.3" }

--- a/picky-server/src/db/file.rs
+++ b/picky-server/src/db/file.rs
@@ -204,7 +204,7 @@ impl PickyStorage for FileStorage {
                 })?;
 
             self.name
-                .insert(&format!("{}{}", name.replace(" ", "_"), TXT_EXT), &addressing_hash)
+                .insert(&format!("{}{}", name.replace(' ', "_"), TXT_EXT), &addressing_hash)
                 .await?;
             self.cert
                 .insert(&format!("{}{}", addressing_hash, DER_EXT), &cert.to_vec())
@@ -247,7 +247,7 @@ impl PickyStorage for FileStorage {
     }
 
     fn get_addressing_hash_by_name(&self, name: &str) -> BoxFuture<'_, Result<String, StorageError>> {
-        let name = format!("{}{}", name, TXT_EXT).replace(" ", "_");
+        let name = format!("{}{}", name, TXT_EXT).replace(' ', "_");
         async move {
             let file = self
                 .name

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = [ "Alexandr Yusuk <aleksandr.yusuk@apriorit.com>" ]
 edition = "2021"
 description = "A signtool like Authenticode sign and verify tool based on picky and lief-rs"
+publish = false
 
 [dependencies]
 anyhow = "1.0.45"

--- a/picky-signtool/src/config.rs
+++ b/picky-signtool/src/config.rs
@@ -34,7 +34,7 @@ pub const ARG_LOGGING_CRITICAL: &str = "critical";
 
 pub fn config() -> ArgMatches<'static> {
     let validate_executable_postfix =
-        |file: String| match Path::new(file.as_str()).extension().map(|ext| ext.to_str()).flatten() {
+        |file: String| match Path::new(file.as_str()).extension().and_then(|ext| ext.to_str()) {
             Some("exe") => Ok(()),
             _ => Err(format!("`{}` is not a Windows executable", file)),
         };

--- a/picky-signtool/src/lib.rs
+++ b/picky-signtool/src/lib.rs
@@ -14,8 +14,7 @@ use config::{
 #[inline]
 pub fn get_utf8_file_name(file: &Path) -> anyhow::Result<&str> {
     file.file_name()
-        .map(|name| name.to_str())
-        .flatten()
+        .and_then(|name| name.to_str())
         .ok_or_else(|| anyhow!("Invalid file name: {:?}", file))
 }
 

--- a/picky-signtool/src/main.rs
+++ b/picky-signtool/src/main.rs
@@ -45,16 +45,13 @@ fn main() -> anyhow::Result<()> {
                     .contents_first(true)
                     .into_iter()
                     .filter_map(|entry| {
-                        entry
-                            .ok()
-                            .map(|entry| {
-                                if is_ps_file(&entry) {
-                                    Some(entry.into_path())
-                                } else {
-                                    None
-                                }
-                            })
-                            .flatten()
+                        entry.ok().and_then(|entry| {
+                            if is_ps_file(&entry) {
+                                Some(entry.into_path())
+                            } else {
+                                None
+                            }
+                        })
                     })
                     .collect::<Vec<PathBuf>>()
             }

--- a/picky-signtool/src/utils.rs
+++ b/picky-signtool/src/utils.rs
@@ -1,3 +1,3 @@
 pub fn str_to_utf16_bytes(s: &str, buff: &mut Vec<u8>) {
-    buff.extend(s.encode_utf16().map(|word| word.to_le_bytes()).flatten())
+    buff.extend(s.encode_utf16().flat_map(|word| word.to_le_bytes()))
 }

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -217,7 +217,7 @@ fn apply_flags<'a>(
     let validator = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_BASIC) {
         validator.require_basic_authenticode_validation(file_hash)
     } else {
-        &validator
+        validator
     };
 
     let validator = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_SIGNING_CERTIFICATE) {
@@ -227,13 +227,13 @@ fn apply_flags<'a>(
             .require_not_before_check()
             .exact_date(time)
     } else {
-        &validator
+        validator
     };
 
     let validator = if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CHAIN) {
         validator.require_chain_check()
     } else {
-        &validator
+        validator
     };
 
     if flags.iter().any(|flag| flag.as_str() == ARG_VERIFY_CA) {

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+
+## [Unreleased] – ReleaseDate
 
 ### Added
 
+- Support for ECDSA p256 and ECDSA p384 signatures (#132)
 - Support for MD5 hashing
 - CTL implementation behind `ctl` feature
 - CTL fetching over HTTP is behind `ctl_http_fetch` feature
@@ -18,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pkcs7::decode_certificates`
 - `impl From<Pkcs7Certificate> for Pkcs7`
 - `impl From<Pkcs7> for Pkcs7Certificate`
-- Add `AuthenticodeSignature` struct
+- `AuthenticodeSignature` struct
 - `AuthenticodeSignature::new`
 - `AuthenticodeSignature::from_der`
 - `AuthenticodeSignature::from_pem`
@@ -37,9 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Method `timestamp` to `AuthenticodeSignature`
   - `Timestamper` trait.
   - Timestamping implementation using reqwest is behind `http_timestamp` feature
-- Add  Authenticode timestamp request struct - `TimestampRequest`
-- Add `AuthenticodeBuilder` for easier `AuthenticodeSignature` creation
-- Add `SignatureAlgorithm::hash_algorithm`
+- Authenticode timestamp request struct - `TimestampRequest`
+- `AuthenticodeBuilder` for easier `AuthenticodeSignature` creation
+- `SignatureAlgorithm::hash_algorithm`
 - Support for `time 0.3` types conversions behind `time_conversion` feature gate
 - `PrivateKey::to_pem_str`
 - `PublicKey::to_pem_str`
@@ -53,10 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump minimal rustc version to 1.56
 
 ### Fixed
+
 - Fix `BufReader` panic in `WinCertificate::decode` and `WinCertificate::encode` if data len is bigger than default capacity.
 - Fix `WinCertificate` encoding: `length` wasn’t correct.
 
-## [6.4.0] 2021-08-10
+## [6.4.0] – 2021-08-10
 
 ### Changed
 
@@ -65,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `picky-asn1` dependency to `0.4`
 - More robust certification validation (see commit [f5f8cb60e41](https://github.com/Devolutions/picky-rs/commit/f5f8cb60e410ffe49aabace131f7b802e206ced0) for details)
 
-## [6.3.0] 2021-05-27
+## [6.3.0] – 2021-05-27
 
 ### Added
 
@@ -76,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `aes-gcm` dependency to `0.9`
 
-## [6.2.0] 2021-03-04
+## [6.2.0] – 2021-03-04
 
 ### Added
 
@@ -84,13 +88,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CertificateBuilder::inherit_extensions_from_csr_attributes` to allow certificate to inherit extensions requested by CSR attribute.
 - Various API additions to `GeneralNames` for improved ergonomics.
 
-## [6.1.2] 2021-01-11
+## 6.1.2 – 2021-01-11
 
 ### Fixed
 
 - Fix bad `use`s statements to `serde::export`
 
-## [6.1.1] 2020-12-11
+## 6.1.1 – 2020-12-11
 
 ### Fixed
 
@@ -98,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix certificate validity period that MUST be encoded as `UTCTime` through the year 2049 as per RFC 5280.
   Previously, they were always encoded as `GeneralizedTime`.
 
-## [6.1.0] 2020-10-21
+## 6.1.0 – 2020-10-21
 
 ### Added
 
@@ -109,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bad generation for second exponent (`pq`) when generating PKCS#8 structure.
 - Serial number was sometimes generated as negative.
 
-## [6.0.0] 2020-10-13
+## 6.0.0 – 2020-10-13
 
 ### Added
 
@@ -134,13 +138,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RSA private key generation ([#53](https://github.com/Devolutions/picky-rs/issues/53)).
 
-## [5.1.1] 2020-07-13
+## 5.1.1 – 2020-07-13
 
 ### Changed
 
 - Better `CaChainError::AuthorityKeyIdMismatch` display.
 
-## [5.1.0] 2020-07-07
+## 5.1.0 – 2020-07-07
 
 ### Added
 
@@ -151,7 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some internal types are moved to a new `picky_asn1_x509` crate but API is unchanged.
 - Dependencies clean up.
 
-## [5.0.0] 2020-05-06
+## 5.0.0 – 2020-05-06
 
 ### Added
 
@@ -171,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing parameters for AES and SHA object identifiers ([668c06e8d](https://github.com/Devolutions/picky-rs/commit/668c06e8d8e8a0caae8bd13cf81c189bbc2e4918))
 
-## [4.7.0] 2020-04-16
+## 4.7.0 – 2020-04-16
 
 ### Added
 
@@ -182,3 +186,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `Cert::verify` and `Cert::verify_chain` methods in favor of the `Cert::verifier` method.
+
+<!-- next-url -->
+[Unreleased]: https://github.com/Devolutions/picky-rs/compare/picky-6.4.0...HEAD
+[6.4.0]: https://github.com/Devolutions/picky-rs/compare/picky-6.3.0...picky-6.4.0
+[6.3.0]: https://github.com/Devolutions/picky-rs/compare/picky-6.2.0...picky-6.3.0
+[6.2.0]: https://github.com/Devolutions/picky-rs/compare/picky-6.1.1...picky-6.2.0

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "6.4.0"
+version = "7.0.0-rc.1"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Jonathan Trepanier <jtrepanier@devolutions.net>",

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -20,7 +20,7 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 [dependencies]
 picky-asn1 = { version = "0.5", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.3", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.6", path = "../picky-asn1-x509", features = ["legacy"] }
+picky-asn1-x509 = { version = "0.7", path = "../picky-asn1-x509", features = ["legacy"] }
 serde = { version = "1.0.130", features = ["derive"] }
 oid = { version = "0.2.1", features = ["serde_support"] }
 base64 = "0.13.0"

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -13,6 +13,7 @@ authors = [
 description = "Portable X.509, PKI, JOSE and HTTP signature implementation."
 keywords = ["x509", "jwt", "signature", "jose", "pki"]
 edition = "2021"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,16 @@
+enable-all-features = true
+
+tag-prefix = "{{crate_name}}-"
+tag-name = "{{prefix}}{{version}}"
+tag-message = "{{crate_name}} v{{version}} release"
+
+pre-release-commit-message = "{{crate_name}}: bump to {{version}}"
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}", exactly = 1 },
+  { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] – ReleaseDate", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/Devolutions/picky-rs/compare/{{tag_name}}...HEAD", exactly = 1 },
+]
+
+post-release-commit-message = "{{crate_name}}: start next iteration {{next_version}}"


### PR DESCRIPTION
Also: initial configuration for [`cargo-release`](https://github.com/crate-ci/cargo-release).

cc @flavio 