### PR TITLE
Separate JWT validation from decoding in JOSE API

### DIFF
--- a/picky-server/src/http/controller.rs
+++ b/picky-server/src/http/controller.rs
@@ -115,7 +115,7 @@ impl ServerController {
     async fn cert_signature_request(&self, req: Request) -> Result<ResponseBuilder, StatusCode> {
         let (locked_subject_name, x509_duration_secs) = match check_authorization(&*self.read_conf().await, &req) {
             Ok(token) => {
-                let provider_claims: ProviderClaims = serde_json::from_value(token.claims).bad_request()?;
+                let provider_claims: ProviderClaims = serde_json::from_value(token.state.claims).bad_request()?;
                 (provider_claims.sub, provider_claims.x509_duration_secs)
             }
             Err(e) => {
@@ -336,7 +336,7 @@ impl ServerController {
         }
 
         let sign_request: SshSignRequest = match check_authorization(&*self.read_conf().await, &req) {
-            Ok(token) => serde_json::from_value(token.claims).bad_request()?,
+            Ok(token) => serde_json::from_value(token.state.claims).bad_request()?,
             Err(e) => {
                 log::error!("authorization failed: {}", e);
                 return Err(StatusCode::UNAUTHORIZED);

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -50,10 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump minimal rustc version to 1.56
 - (Breaking) Move Authenticode related code from `picky::x509::wincert` to `picky::x509::pkcs7::authenticode` module
 - (Breaking) Authenticode implementation is now behind `pkcs7` feature
 - (Breaking) `PrivateKey::to_pem` and `PublicKey::to_pem` now return a `Pem`
-- Bump minimal rustc version to 1.56
+- (Breaking) Separate JWT validation from decoding in JOSE API (this makes API more convenient to first process header
+    and then decide what kind of validation should be applied, or what claims type to deserialize into)
 
 ### Fixed
 


### PR DESCRIPTION
This makes API more convenient to first process header and then decide what kind of validation should be applied, or what claims type to deserialize into.