### PR TITLE
Some improvements regarding Kerberos module in sspi-rs

### DIFF
--- a/picky-asn1-der/src/application_tag.rs
+++ b/picky-asn1-der/src/application_tag.rs
@@ -8,11 +8,17 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 #[derive(Debug, PartialEq)]
-pub struct ApplicationTag<V: Debug + PartialEq, const T: u8>(V);
+pub struct ApplicationTag<V: Debug + PartialEq, const T: u8>(pub V);
 
 impl<V: Debug + PartialEq, const T: u8> ApplicationTag<V, T> {
     pub fn from(value: V) -> Self {
         Self(value)
+    }
+}
+
+impl<V: Clone + PartialEq + Debug, const T: u8> Clone for ApplicationTag<V, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 
@@ -77,7 +83,7 @@ impl<'de, V: de::Deserialize<'de> + Debug + PartialEq, const T: u8> de::Deserial
     }
 }
 
-impl<V: ser::Serialize + Debug + PartialEq, const T: u8> ser::Serialize for ApplicationTag<V, T> {
+impl<V: ser::Serialize + Debug + PartialEq + Clone, const T: u8> ser::Serialize for ApplicationTag<V, T> {
     fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, S::Error>
     where
         S: ser::Serializer,

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -206,4 +206,11 @@ define_oid! {
     UNKNOWN_RESERVED_PROP_ID_127 => unknown_reserved_prop_id_127 => "1.3.6.1.4.1.311.10.11.127",
 
     AUTO_UPDATE_END_REVOCATION => auto_update_end_revocation => "1.3.6.1.4.1.311.60.3.2",
+
+    // NLA protocols
+    KRB5 => krb5 => "1.2.840.113554.1.2.2",
+    MS_KRB5 => ms_krb5 => "1.2.840.48018.1.2.2",
+    KRB5_USER_TO_USER => krb5_user_to_user => "1.2.840.113554.1.2.2.3",
+    NTLM_SSP => ntlm_ssp => "1.3.6.1.4.1.311.2.2.10",
+    SPNEGO => spnego => "1.3.6.1.5.5.2",
 }


### PR DESCRIPTION
`picky-asn1-der`:
* Improved the const-generic `ApplicationTag`: make inner value public and add requiring the `Clone` trait.

`picky-asn1-x509`:
* Add NLA protocols OIDs.