### PR TITLE
picky-krb: add missing Kerberos name type constants

### DIFF
--- a/picky-krb/src/constants.rs
+++ b/picky-krb/src/constants.rs
@@ -10,8 +10,15 @@ pub mod types {
 
     pub const KRB_ERROR_MSG_TYPE: u8 = 0x1e;
 
+    pub const NT_UNKNOWN: u8 = 0x00;
     pub const NT_PRINCIPAL: u8 = 0x01;
     pub const NT_SRV_INST: u8 = 0x02;
+    pub const NT_SRV_HST: u8 = 0x03;
+    pub const NT_SRV_XHST: u8 = 0x04;
+    pub const NT_UID: u8 = 0x05;
+    pub const NT_X500_PRINCIPAL: u8 = 0x06;
+    pub const NT_SMTP_NAME: u8 = 0x07;
+    pub const NT_ENTERPRISE: u8 = 0x0A;
 
     pub const PA_ENC_TIMESTAMP: [u8; 1] = [0x02];
     pub const PA_ENC_TIMESTAMP_KEY_USAGE: i32 = 1;


### PR DESCRIPTION
Add missing Kerberos name type constants (https://www.rfc-editor.org/rfc/rfc4120#section-7.5.8) which we'll need in sspi-rs to handle NT_PRINCIPAL (1) and NT_ENTERPRISE (10) name types [based on the username formats (netbios versus UPN)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c). We can temporarily just hardcode the value in sspi-rs until the next release of picky-krb.