### PR TITLE
ci: fix NuGet publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@ name: Publish npm package
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '48 3 * * 1' # 3:48 AM UTC every Monday
 
 jobs:
   publish:
@@ -32,6 +34,7 @@ jobs:
           ./run_tests.ps1
 
       - name: Build & Publish
+        if: github.event_name != 'schedule'
         shell: pwsh
         run: |
           Set-Location ./ffi/wasm

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -56,7 +56,6 @@ jobs:
       
       - name: Install NDK21
         if: matrix.os == 'android'
-        shell: pwsh
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
@@ -65,7 +64,6 @@ jobs:
 
       - name: Make NDK21 default
         if: matrix.os == 'android'
-        shell: pwsh
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -52,16 +52,16 @@ jobs:
           $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin"
 
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang.exe`"" >> $CargoConfigFile
 
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang.exe`"" >> $CargoConfigFile
 
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang.exe`"" >> $CargoConfigFile
 
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.exe`"" >> $CargoConfigFile
       
       - name: Work around ndk-bundle symlink issue
         if: matrix.os == 'android'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -54,16 +54,16 @@ jobs:
           Get-ChildItem $AndroidToolchainBin -Recurse
 
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang.cmd`"" >> $CargoConfigFile
 
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang.cmd`"" >> $CargoConfigFile
 
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang.cmd`"" >> $CargoConfigFile
 
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.cmd`"" >> $CargoConfigFile
       
       # - name: Work around ndk-bundle symlink issue
       #   if: matrix.os == 'android'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -65,17 +65,17 @@ jobs:
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
           echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.cmd`"" >> $CargoConfigFile
       
-      # - name: Work around ndk-bundle symlink issue
-      #   if: matrix.os == 'android'
-      #   shell: pwsh
-      #   run: |
-      #     $sdkRoot = "C:\Android\android-sdk"
-      #     $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
-      #     Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
-      #                               -AndroidSDKRootPath $sdkRoot `
-      #                               -AndroidPackages "ndk;21.4.7075529"
-      #     $ndkRoot = "$sdkRoot\ndk-bundle"
-      #     New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
+      - name: Work around ndk-bundle symlink issue
+        if: matrix.os == 'android'
+        shell: pwsh
+        run: |
+          $sdkRoot = "C:\Android\android-sdk"
+          $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
+          Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
+                                    -AndroidSDKRootPath $sdkRoot `
+                                    -AndroidPackages "ndk;21.4.7075529"
+          $ndkRoot = "$sdkRoot\ndk-bundle"
+          New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
   
       - name: Build picky (${{matrix.os}}-${{matrix.arch}})
         shell: pwsh

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -54,16 +54,16 @@ jobs:
           Get-ChildItem $AndroidToolchainBin -Recurse
 
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang.exe`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang`"" >> $CargoConfigFile
 
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang.exe`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang`"" >> $CargoConfigFile
 
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang.exe`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
 
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.exe`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang`"" >> $CargoConfigFile
       
       # - name: Work around ndk-bundle symlink issue
       #   if: matrix.os == 'android'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,4 +1,5 @@
 name: nuget package
+# name: Publish NuGet package
 on: workflow_dispatch
 jobs:
   build-native:
@@ -19,7 +20,7 @@ jobs:
           - os: ios
             runner: macos-11
           - os: android
-            runner: ubuntu-20.04
+            runner: windows-2022
         exclude:
           - arch: arm
             os: win
@@ -43,27 +44,42 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Android NDK
-        if: runner.os == 'linux'
+        if: matrix.os == 'android'
         shell: pwsh
         run: |
           $CargoConfigFile = "~/.cargo/config"
-          $AndroidToolchainBin="${Env:ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          
+          $AndroidNdkHome = ${Env:ANDROID_NDK_HOME} -Replace '\\', '\\'
+          $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\linux-x86_64\\bin"
+
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin/i686-linux-android16-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang`"" >> $CargoConfigFile
 
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin/x86_64-linux-android21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang`"" >> $CargoConfigFile
 
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin/armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
 
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin/aarch64-linux-android21-clang`"" >> $CargoConfigFile
-
+          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang`"" >> $CargoConfigFile
+      
+      - name: Work around ndk-bundle symlink issue
+        if: matrix.os == 'android'
+        shell: pwsh
+        run: |
+          $sdkRoot = "C:\Android\android-sdk"
+          $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
+          Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
+                                    -AndroidSDKRootPath $sdkRoot `
+                                    -AndroidPackages "ndk;21.4.7075529"
+          $ndkRoot = "$sdkRoot\ndk-bundle"
+          New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
+  
       - name: Build picky (${{matrix.os}}-${{matrix.arch}})
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           $DotNetOs = '${{matrix.os}}'
           $DotNetArch = '${{matrix.arch}}'
           $DotNetRid = '${{matrix.os}}-${{matrix.arch}}'
@@ -82,7 +98,7 @@ jobs:
             $RustTarget = "armv7-linux-androideabi"
           }
 
-          & rustup target add $RustTarget
+          rustup target add $RustTarget
 
           if ($DotNetOs -eq 'win') {
             $Env:RUSTFLAGS="-C target-feature=+crt-static"
@@ -97,7 +113,7 @@ jobs:
           }
 
           if ($RustTarget -eq 'aarch64-unknown-linux-gnu') {
-            & sudo apt install gcc-aarch64-linux-gnu
+            sudo apt install gcc-aarch64-linux-gnu
             $Env:RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
           }
 
@@ -111,7 +127,7 @@ jobs:
           }
           Set-Content -Path .\ffi\Cargo.toml -Value $CargoToml
 
-          & cargo build -p picky-ffi --release --target $RustTarget
+          cargo build -p picky-ffi --release --target $RustTarget
 
           $OutputLibraryName = "${LibPrefix}picky$LibSuffix"
           $RenamedLibraryName = "${LibPrefix}DevolutionsPicky$LibSuffix"
@@ -153,7 +169,7 @@ jobs:
       - name: Build picky (managed)
         shell: pwsh
         run: |
-          & dotnet build .\ffi\dotnet\Devolutions.Picky.sln -o package
+          dotnet build .\ffi\dotnet\Devolutions.Picky.sln -o package
 
       - name: Upload managed components
         uses: actions/upload-artifact@v2

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,6 +1,10 @@
-name: nuget package
-# name: Publish NuGet package
-on: workflow_dispatch
+name: Publish NuGet package
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '21 3 * * 1' # 3:21 AM UTC every Monday
+
 jobs:
   build-native:
     name: native build
@@ -149,7 +153,7 @@ jobs:
 
     steps:
       - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare dependencies
         run: |
@@ -176,3 +180,47 @@ jobs:
         with:
           name: picky-nupkg
           path: package/*.nupkg
+
+  publish:
+    name: publish
+    runs-on: ubuntu-18.04
+    needs: build-managed
+    environment: artifactory-publish      
+    if: github.event_name != 'schedule'
+  
+    steps:
+      - name: Configure runner
+        run: |
+          curl -fL https://getcli.jfrog.io/v2 | sh
+          echo "$PWD" >> $GITHUB_PATH
+
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: picky-nupkg
+          path: package
+
+      - name: Publish to artifactory
+        shell: pwsh
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          $Files = Get-ChildItem -Recurse package/*.toml
+    
+          foreach ($File in $Files) {
+            $UploadCmd = @(
+              'jfrog', 
+              'rt', 
+              'upload', 
+              "$File",
+              'nuget', 
+              '--url=https://devolutions.jfrog.io/artifactory/',
+              "--user=$Env:ARTIFACTORY_USERNAME",
+              "--password=$Env:ARTIFACTORY_PASSWORD"
+            )
+
+            Write-Host "Publishing $($File.Name)..."
+            $UploadCmd = $UploadCmd -Join ' '
+            Invoke-Expression $UploadCmd
+          }

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -63,17 +63,17 @@ jobs:
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
           echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.exe`"" >> $CargoConfigFile
       
-      - name: Work around ndk-bundle symlink issue
-        if: matrix.os == 'android'
-        shell: pwsh
-        run: |
-          $sdkRoot = "C:\Android\android-sdk"
-          $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
-          Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
-                                    -AndroidSDKRootPath $sdkRoot `
-                                    -AndroidPackages "ndk;21.4.7075529"
-          $ndkRoot = "$sdkRoot\ndk-bundle"
-          New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
+      # - name: Work around ndk-bundle symlink issue
+      #   if: matrix.os == 'android'
+      #   shell: pwsh
+      #   run: |
+      #     $sdkRoot = "C:\Android\android-sdk"
+      #     $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
+      #     Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
+      #                               -AndroidSDKRootPath $sdkRoot `
+      #                               -AndroidPackages "ndk;21.4.7075529"
+      #     $ndkRoot = "$sdkRoot\ndk-bundle"
+      #     New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
   
       - name: Build picky (${{matrix.os}}-${{matrix.arch}})
         shell: pwsh

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -48,11 +48,16 @@ jobs:
         shell: pwsh
         run: |
           $CargoConfigFile = "~/.cargo/config"
-
+          $AndroidToolchainBin="${Env:ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          
           echo "[target.i686-linux-android]" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin/i686-linux-android16-clang`"" >> $CargoConfigFile
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin/x86_64-linux-android21-clang`"" >> $CargoConfigFile
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin/armv7a-linux-androideabi21-clang`"" >> $CargoConfigFile
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchainBin/aarch64-linux-android21-clang`"" >> $CargoConfigFile
       
       - name: Install NDK21
         if: matrix.os == 'android'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           $CargoConfigFile = "~/.cargo/config"
           $AndroidNdkHome = ${Env:ANDROID_NDK_HOME} -Replace '\\', '\\'
-          $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\linux-x86_64\\bin"
+          $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin"
 
           echo "[target.i686-linux-android]" >> $CargoConfigFile
           echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang`"" >> $CargoConfigFile

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -20,7 +20,7 @@ jobs:
           - os: ios
             runner: macos-11
           - os: android
-            runner: windows-2022
+            runner: ubuntu-20.04
         exclude:
           - arch: arm
             os: win
@@ -44,38 +44,33 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Android NDK
-        if: matrix.os == 'android'
+        if: runner.os == 'linux'
         shell: pwsh
         run: |
           $CargoConfigFile = "~/.cargo/config"
-          $AndroidNdkHome = ${Env:ANDROID_NDK_HOME} -Replace '\\', '\\'
-          $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin"
-
-          Get-ChildItem $AndroidToolchainBin -Recurse
 
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang.cmd`"" >> $CargoConfigFile
-
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\x86_64-linux-android21-clang.cmd`"" >> $CargoConfigFile
-
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\armv7a-linux-androideabi21-clang.cmd`"" >> $CargoConfigFile
-
           echo "[target.aarch64-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchainBin\\aarch64-linux-android21-clang.cmd`"" >> $CargoConfigFile
       
-      - name: Work around ndk-bundle symlink issue
+      - name: Install NDK21
         if: matrix.os == 'android'
         shell: pwsh
         run: |
-          $sdkRoot = "C:\Android\android-sdk"
-          $sdkManager = "$sdkRoot\cmdline-tools\latest\bin\sdkmanager.bat"
-          Install-AndroidSDKPackages -AndroidSDKManagerPath $sdkManager `
-                                    -AndroidSDKRootPath $sdkRoot `
-                                    -AndroidPackages "ndk;21.4.7075529"
-          $ndkRoot = "$sdkRoot\ndk-bundle"
-          New-Item -Path $ndkRoot -ItemType SymbolicLink -Value "$sdkRoot\ndk\21.4.7075529" -Force
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+
+      - name: Make NDK21 default
+        if: matrix.os == 'android'
+        shell: pwsh
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
   
       - name: Build picky (${{matrix.os}}-${{matrix.arch}})
         shell: pwsh

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -51,6 +51,8 @@ jobs:
           $AndroidNdkHome = ${Env:ANDROID_NDK_HOME} -Replace '\\', '\\'
           $AndroidToolchainBin="${AndroidNdkHome}\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin"
 
+          Get-ChildItem $AndroidToolchainBin -Recurse
+
           echo "[target.i686-linux-android]" >> $CargoConfigFile
           echo "linker=`"$AndroidToolchainBin\\i686-linux-android16-clang.exe`"" >> $CargoConfigFile
 


### PR DESCRIPTION
- Fixes previously failing NuGet workflow
- Adds the actual publish to artifactory job (was missing)
- Adds scheduled runs just to get notified when the workflow is broken because of runner image update in the future