### PR TITLE
fix(wasm): use `bundler` target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "picky-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-wasm"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Benoît CORTIER <bcortier@proton.me>"]
 edition = "2021"
 publish = false

--- a/ffi/wasm/publish.ps1
+++ b/ffi/wasm/publish.ps1
@@ -2,7 +2,7 @@
 
 $ErrorActionPreference = "Stop"
 
-wasm-pack build --target web --scope devolutions --out-name picky --features wee_alloc
+wasm-pack build --target bundler --scope devolutions --out-name picky --features wee_alloc
 
 if ($LastExitCode -ne 0)
 {


### PR DESCRIPTION
This gives the best user experience when using frameworks such as Angular and React