### PR TITLE
ci: actually fix dry run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,11 +2,12 @@ name: Publish npm package
 
 on:
   workflow_dispatch:
-    dry-run:
-      description: 'Dry run'
-      required: true
-      type: boolean
-      default: 'true'
+    inputs:
+      dry-run:
+        description: 'Dry run'
+        required: true
+        type: boolean
+        default: 'true'
   schedule:
     - cron: '48 3 * * 1' # 3:48 AM UTC every Monday
 

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -2,11 +2,12 @@ name: Publish NuGet package
 
 on:
   workflow_dispatch:
-    dry-run:
-      description: 'Dry run'
-      required: true
-      type: boolean
-      default: 'true'
+    inputs:
+      dry-run:
+        description: 'Dry run'
+        required: true
+        type: boolean
+        default: 'true'
   schedule:
     - cron: '21 3 * * 1' # 3:21 AM UTC every Monday
 


### PR DESCRIPTION
The inputs need to be under the `inputs` key.