### PR TITLE
Fix native library issues for iOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.3.0"
-source = "git+https://github.com/CBenoit/diplomat.git?rev=fc3a85ff1e9bb90b8e088959f9b96e678e7a878f#fc3a85ff1e9bb90b8e088959f9b96e678e7a878f"
+source = "git+https://github.com/CBenoit/diplomat.git?rev=0257abe01196eb68c254e47b516fc089c7d460c4#0257abe01196eb68c254e47b516fc089c7d460c4"
 dependencies = [
  "diplomat_core",
  "lazy_static",
@@ -416,12 +416,12 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.3.0"
-source = "git+https://github.com/CBenoit/diplomat.git?rev=fc3a85ff1e9bb90b8e088959f9b96e678e7a878f#fc3a85ff1e9bb90b8e088959f9b96e678e7a878f"
+source = "git+https://github.com/CBenoit/diplomat.git?rev=0257abe01196eb68c254e47b516fc089c7d460c4#0257abe01196eb68c254e47b516fc089c7d460c4"
 
 [[package]]
 name = "diplomat_core"
 version = "0.3.0"
-source = "git+https://github.com/CBenoit/diplomat.git?rev=fc3a85ff1e9bb90b8e088959f9b96e678e7a878f#fc3a85ff1e9bb90b8e088959f9b96e678e7a878f"
+source = "git+https://github.com/CBenoit/diplomat.git?rev=0257abe01196eb68c254e47b516fc089c7d460c4#0257abe01196eb68c254e47b516fc089c7d460c4"
 dependencies = [
  "impls",
  "lazy_static",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,8 +18,8 @@ embed-resource = "1.7.2"
 picky = { path = "../picky/", default-features = false, features = ["ssh", "x509", "time_conversion", "jose"] }
 
 # FFI
-diplomat = { git = "https://github.com/CBenoit/diplomat.git", rev = "fc3a85ff1e9bb90b8e088959f9b96e678e7a878f" }
-diplomat-runtime = { git = "https://github.com/CBenoit/diplomat.git", rev = "fc3a85ff1e9bb90b8e088959f9b96e678e7a878f" }
+diplomat = { git = "https://github.com/CBenoit/diplomat.git", rev = "0257abe01196eb68c254e47b516fc089c7d460c4" }
+diplomat-runtime = { git = "https://github.com/CBenoit/diplomat.git", rev = "0257abe01196eb68c254e47b516fc089c7d460c4" }
 
 time = "0.3.9"
 hex = "0.4.3"

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -5,7 +5,7 @@
     <Description>Bindings to Rust picky native library</Description>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2022.9.29.0</Version>
+    <Version>2022.10.13.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -168,6 +168,7 @@
 
   <ItemGroup>
     <Content Include="Devolutions.Picky.targets" PackagePath="build/Devolutions.Picky.targets" Pack="true" />
+    <Content Include="Devolutions.Picky.props" PackagePath="build/Devolutions.Picky.props" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.props
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.props
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="(('$(Platform)' == 'iPhone')) or (('$(Platform)' == 'iPhoneSimulator'))">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\runtimes\ios-universal\native\libDevolutionsPicky.framework">
+      <Kind>Framework</Kind>
+    </NativeReference>
+  </ItemGroup>
+</Project>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -83,9 +83,4 @@
           <Abi>x86_64</Abi>
       </AndroidNativeLibrary>
   </ItemGroup> 
-  <ItemGroup Condition="(('$(Platform)' == 'iPhone')) or (('$(Platform)' == 'iPhoneSimulator'))">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\runtimes\ios-universal\native\libDevolutionsPicky.framework">
-      <Kind>Framework</Kind>
-    </NativeReference>
-  </ItemGroup>
 </Project>

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawDateFfiResultBoxUtcDateBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawDateFfiResultBoxUtcDateBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct DateFfiResultBoxUtcDateBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawDateFfiResultI64BoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawDateFfiResultI64BoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct DateFfiResultI64BoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawJwtFfiResultBoxJwtSigBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawJwtFfiResultBoxJwtSigBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct JwtFfiResultBoxJwtSigBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawJwtFfiResultVoidBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawJwtFfiResultVoidBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct JwtFfiResultVoidBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPemBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPemBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct KeyFfiResultBoxPemBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPrivateKeyBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPrivateKeyBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct KeyFfiResultBoxPrivateKeyBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPublicKeyBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawKeyFfiResultBoxPublicKeyBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct KeyFfiResultBoxPublicKeyBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawPemFfiResultBoxPemBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawPemFfiResultBoxPemBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct PemFfiResultBoxPemBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawPemFfiResultVoidBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawPemFfiResultVoidBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct PemFfiResultVoidBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSignatureFfiResultBoxSignatureAlgorithmBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSignatureFfiResultBoxSignatureAlgorithmBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SignatureFfiResultBoxSignatureAlgorithmBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSignatureFfiResultVoidBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSignatureFfiResultVoidBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SignatureFfiResultVoidBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxPemBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxPemBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SshFfiResultBoxPemBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshCertBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshCertBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SshFfiResultBoxSshCertBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshPrivateKeyBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshPrivateKeyBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SshFfiResultBoxSshPrivateKeyBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshPublicKeyBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultBoxSshPublicKeyBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SshFfiResultBoxSshPublicKeyBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultVoidBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawSshFfiResultVoidBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct SshFfiResultVoidBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultBoxCertBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultBoxCertBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct X509FfiResultBoxCertBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultBoxPemBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultBoxPemBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct X509FfiResultBoxPemBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultVoidBoxPickyError.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawX509FfiResultVoidBoxPickyError.cs
@@ -14,7 +14,11 @@ namespace Devolutions.Picky.Raw;
 [StructLayout(LayoutKind.Sequential)]
 public partial struct X509FfiResultVoidBoxPickyError
 {
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
     private const string NativeLib = "DevolutionsPicky";
+#endif
 
     [StructLayout(LayoutKind.Explicit)]
     private unsafe struct InnerUnion

--- a/ffi/justfile
+++ b/ffi/justfile
@@ -19,7 +19,7 @@ default: bindings
 # are not blittables, causing Result types to not be
 # correctly send at the FFI boundary. 
 diplomat_repo := "https://github.com/CBenoit/diplomat.git"
-diplomat_rev  := "fc3a85ff1e9bb90b8e088959f9b96e678e7a878f"
+diplomat_rev  := "0257abe01196eb68c254e47b516fc089c7d460c4"
 
 diplomat-install:
     cargo install --git {{diplomat_repo}} --rev {{diplomat_rev}} diplomat-tool -f


### PR DESCRIPTION
- Add missing library redirections
- Link the native library in a .props file (this seems to resolve some issues reported by RDM team around building)