### PR TITLE
Conditionally set Apple deployment target

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -161,11 +161,17 @@ jobs:
 
           rustup default prebuilt
 
+      - name: Setup build environment
+        shell: pwsh
+        run: |
+          if ('${{ matrix.os }}' -Eq 'osx') {
+            echo "MACOSX_DEPLOYMENT_TARGET=10.10" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          } elseif ('${{ matrix.os }}' -Eq 'ios') {
+            echo "IPHONEOS_DEPLOYMENT_TARGET=12.1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
       - name: Build picky (${{matrix.os}}-${{matrix.arch}})
         shell: pwsh
-        env:
-          MACOSX_DEPLOYMENT_TARGET: '10.10'
-          IPHONEOS_DEPLOYMENT_TARGET: '12.1'
         run: |
           Set-PSDebug -Trace 1
 


### PR DESCRIPTION
Avoid potential issue if a dependent crate considers `IPHONEOS_DEPLOYMENT_TARGET` even when building for macOS.