### PR TITLE
feat(dotnet): support returning Pem data

### DIFF
--- a/ffi/dotnet/Devolutions.Picky.Tests/PemTests.cs
+++ b/ffi/dotnet/Devolutions.Picky.Tests/PemTests.cs
@@ -40,9 +40,8 @@ Od8i323fM5dQS1qQpBjBc/5fPw==
     public void Smoke()
     {
         Pem fromReprPem = Pem.Parse(certPemRepr);
-        // TODO: need support for returning buffer of bytes
-        // Pem fromDataPem = Pem.New(fromReprPem.Label, fromReprPem.ToData());
-        // Assert.Equal(certPemRepr, fromDataPem.ToRepr());
+        Pem fromDataPem = Pem.New(fromReprPem.Label, fromReprPem.ToData());
+        Assert.Equal(certPemRepr, fromDataPem.ToRepr());
     }
 
     [Fact]

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -5,7 +5,7 @@
     <Description>Bindings to Rust picky native library</Description>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2022.10.19.0</Version>
+    <Version>2022.10.21.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ffi/dotnet/Devolutions.Picky/src/Pem.Addons.cs
+++ b/ffi/dotnet/Devolutions.Picky/src/Pem.Addons.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Devolutions.Picky.Diplomat;
+
+namespace Devolutions.Picky;
+
+public partial class Pem
+{
+	// TODO: maybe this should be part of the Diplomat namespace in DiplomatRuntime.cs
+#if __IOS__
+    private const string NativeLib = "libDevolutionsPicky.framework/libDevolutionsPicky";
+#else
+    private const string NativeLib = "DevolutionsPicky";
+#endif
+
+	/// Returned data should not be modified!
+	[DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Pem_peek_data", ExactSpelling = true)]
+	internal static unsafe extern IntPtr PeekData(Raw.Pem* self, out nuint len);
+
+    public byte[] ToData()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("Pem");
+            }
+
+			nuint dataLen;
+            IntPtr dataPtr = PeekData(_inner, out dataLen);
+
+			byte[] retVal = new byte[dataLen];
+			Marshal.Copy(dataPtr, retVal, 0, (int)dataLen);
+
+			return retVal;
+        }
+    }
+}

--- a/ffi/src/pem.rs
+++ b/ffi/src/pem.rs
@@ -62,3 +62,15 @@ pub mod ffi {
         }
     }
 }
+
+/// Returned data should not be modified!
+#[no_mangle]
+pub unsafe extern "C" fn Pem_peek_data(pem: Option<&ffi::Pem>, len: *mut usize) -> *const u8 {
+    if let Some(pem) = pem {
+        let data = pem.0.data();
+        *len = data.len();
+        data.as_ptr()
+    } else {
+        core::ptr::null()
+    }
+}

--- a/ffi/src/pem.rs
+++ b/ffi/src/pem.rs
@@ -63,7 +63,11 @@ pub mod ffi {
     }
 }
 
-/// Returned data should not be modified!
+/// Retuns data contained in this Pem object.
+///
+/// # Safety
+///
+/// Returned data should not be modified.
 #[no_mangle]
 pub unsafe extern "C" fn Pem_peek_data(pem: Option<&ffi::Pem>, len: *mut usize) -> *const u8 {
     if let Some(pem) = pem {


### PR DESCRIPTION
Until array support is added to diplomat, we do the FFI dance manually.