### PR TITLE
Fixes for mobile nuget

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,9 +26,9 @@ jobs:
           $IsDryRun = '${{ github.event.inputs.dry-run }}' -Eq 'true' -Or '${{ github.event_name }}' -Eq 'schedule'
 
           if ($IsDryRun) {
-            Write-Host '::set-output name=dry-run::true'
+            echo "dry-run=true" >> $Env:GITHUB_OUTPUT
           } else {
-            Write-Host '::set-output name=dry-run::false'
+            echo "dry-run=false" >> $Env:GITHUB_OUTPUT
           }
 
   tests:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -33,9 +33,9 @@ jobs:
           $IsDryRun = '${{ github.event.inputs.dry-run }}' -Eq 'true' -Or '${{ github.event_name }}' -Eq 'schedule'
 
           if ($IsDryRun) {
-            Write-Host '::set-output name=dry-run::true'
+            echo "dry-run=true" >> $Env:GITHUB_OUTPUT
           } else {
-            Write-Host '::set-output name=dry-run::false'
+            echo "dry-run=false" >> $Env:GITHUB_OUTPUT
           }
 
       - name: Get version
@@ -45,8 +45,8 @@ jobs:
           $CsprojXml = [Xml] (Get-Content .\ffi\dotnet\Devolutions.Picky\Devolutions.Picky.csproj)
           $ProjectVersion = $CsprojXml.Project.PropertyGroup.Version | Select-Object -First 1
           $PackageVersion = $ProjectVersion -Replace "^(\d+)\.(\d+)\.(\d+).(\d+)$", "`$1.`$2.`$3"
-          Write-Host "::set-output name=project-version::$ProjectVersion"
-          Write-Host "::set-output name=package-version::$PackageVersion"
+          echo "project-version=$ProjectVersion" >> $Env:GITHUB_OUTPUT
+          echo "package-version=$PackageVersion" >> $Env:GITHUB_OUTPUT
 
   build-native:
     name: Native build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           $RunJson = gh api /repos/devolutions/picky-rs/actions/runs/${{ github.event.inputs.run-id }}
           $Run = $RunJson | ConvertFrom-Json
-          echo "::set-output name=commit::$($Run.head_sha)"
+          echo "commit=$($Run.head_sha)" >> $Env:GITHUB_OUTPUT
 
       - name: Print output
         shell: pwsh
@@ -72,7 +72,7 @@ jobs:
         run: |
           $Data = Select-String -Pattern 'version' $(Join-Path server Cargo.toml) | Select-Object -First 1
           $Data -Match "(\d*\.\d*\.\d*)"
-          echo "::set-output name=version::$($matches[0])"
+          echo "version=$($matches[0])" >> $Env:GITHUB_OUTPUT
 
       - name: Download and copy artifacts
         id: download
@@ -109,7 +109,7 @@ jobs:
           } else {
             docker build -t "$ImageName" .
           }
-          echo "::set-output name=image-name::$ImageName"
+          echo "image-name=$ImageName" >> $Env:GITHUB_OUTPUT
 
       - name: Push container
         shell: pwsh

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.Build.iOS.props
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.Build.iOS.props
@@ -1,40 +1,13 @@
 <Project>
 
   <PropertyGroup Condition="$(PackageId.EndsWith('iOS'))">
-    <TargetFrameworks>net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net6.0-ios</TargetFrameworks>
     <SupportedOSPlatformVersion>12.1</SupportedOSPlatformVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_x64)')">
-    <Content Include="$(NativeLibPath_ios_x64)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_arm64)')">
-    <Content Include="$(NativeLibPath_ios_arm64)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-arm64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_universal)')">
-    <Content Include="$(NativeLibPath_ios_universal)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-universal/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <ItemGroup Condition="Exists('$(NativeLibPath_ios_framework)')">
     <None Include="$(RuntimesPath)/ios-universal/native/*.framework/**">
-      <PackagePath>runtimes/ios-universal/native/</PackagePath>
+      <PackagePath>runtimes/ios/native/</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -5,7 +5,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust picky native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2022.10.21.0</Version>
+    <Version>2022.11.14.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.iOS.props
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.iOS.props
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="(('$(Platform)' == 'iPhone')) or (('$(Platform)' == 'iPhoneSimulator'))">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\runtimes\ios-universal\native\libDevolutionsPicky.framework">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\runtimes\ios\native\libDevolutionsPicky.framework">
       <Kind>Framework</Kind>
     </NativeReference>
   </ItemGroup>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <IsPowerShell Condition="$(DefineConstants.Contains('__POWERSHELL__'))">true</IsPowerShell>
-    <IsAndroid Condition="$(AndroidSupportedAbis) != '' or $(RuntimeIdentifiers.Contains('android'))">true</IsAndroid>
+    <IsAndroid Condition="$(TargetFramework.ToUpper().Contains('ANDROID'))">true</IsAndroid>
     <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">true</IsIOS>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
On Android, the check for `IsAndroid` in MSBuild appeared valid but wasn't working for some reason under net6.0-android targets. This causes the `NativeReference` element to be evaluated on that platform, and MSBuild would try to link the macOS .dylib. Changing the condition to check the current TargetFramework for "Android" seems to work well everywhere.

On iOS, the net7.0-ios target is rolled back to net6.0-ios for better compatibility. I removed the bare .dylibs from the package - `dotnet build` seems to pick up the references at packaging time and then fails because of "duplicate resource keys". Since we don't use the bare .dylibs, I just removed them from the package. Next, there were build failures consuming the package in net6.0-ios and net7.0-ios targets - the linker was unable to locate the framework. For some reason, changing the packaging directory from "ios-universal" to "ios" fixes this. Since we are creating the native reference ourselves, it's not clear why it's sensitive to the RID in the path - but "ios-universal" was our own fabrication anyway, since there's no "true" universal RID(s) for Apple platforms.

Finally, I incremented the version number and ported the `set-output` usages in GitHub Actions to environment files.