### PR TITLE
fix(ffi): link thin binaries on macOS net6 targets

### DIFF
--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -5,7 +5,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust picky native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2022.11.29.0</Version>
+    <Version>2022.12.9.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -38,7 +38,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsPicky.dylib">
+    <Content Condition="'$(IsPowerShell)' == 'true' OR $(RuntimeIdentifiers.Contains('osx-x64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsPicky.dylib">
       <Link>runtimes\osx-x64\native\libDevolutionsPicky.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -46,7 +46,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsPicky.dylib">
+    <Content Condition="'$(IsPowerShell)' == 'true' OR $(RuntimeIdentifiers.Contains('osx-arm64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsPicky.dylib">
       <Link>runtimes\osx-arm64\native\libDevolutionsPicky.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>


### PR DESCRIPTION
`dotnet build` will look for native dependencies in the _runtimes_ path and `lipo` them automatically if needed. 