### PR TITLE
fix(ffi): Fix net6-macos packaging

### DIFF
--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.csproj
@@ -5,7 +5,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust picky native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2022.12.9.0</Version>
+    <Version>2022.12.12.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -6,6 +6,8 @@
     <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">true</IsIOS>
   </PropertyGroup>
   <ItemGroup>
+  
+    <!-- Windows or PowerShell -->
     <Content Condition="$([MSBuild]::IsOSPlatform('Windows')) OR '$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\DevolutionsPicky.dll">
       <Link>runtimes\win-x64\native\DevolutionsPicky.dll</Link>
       <PublishState>Included</PublishState>
@@ -22,6 +24,8 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
+
+    <!-- Linux or PowerShell -->
     <Content Condition="$([MSBuild]::IsOSPlatform('Linux')) OR '$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\libDevolutionsPicky.so">
       <Link>runtimes\linux-x64\native\libDevolutionsPicky.so</Link>
       <PublishState>Included</PublishState>
@@ -38,7 +42,9 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true' OR $(RuntimeIdentifiers.Contains('osx-x64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsPicky.dylib">
+
+    <!-- PowerShell -->
+    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsPicky.dylib">
       <Link>runtimes\osx-x64\native\libDevolutionsPicky.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -46,7 +52,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true' OR $(RuntimeIdentifiers.Contains('osx-arm64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsPicky.dylib">
+    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsPicky.dylib">
       <Link>runtimes\osx-arm64\native\libDevolutionsPicky.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -55,12 +61,16 @@
       <Pack>false</Pack>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true'">
+
+  <!-- Xamarin.Mac -->
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND $(RuntimeIdentifiers.Contains('osx-')) != 'true'">
     <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsPicky.dylib">
       <Kind>Dynamic</Kind>
       <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
+
+  <!-- Xamarin.Android or net6.0-android -->
   <ItemGroup Condition="$(AndroidSupportedAbis.Contains('armeabi-v7a')) or $(RuntimeIdentifiers.Contains('android-arm'))">
       <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsPicky.so">
           <Link>%(Filename)%(Extension)</Link>

--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -4,6 +4,7 @@
     <IsPowerShell Condition="$(DefineConstants.Contains('__POWERSHELL__'))">true</IsPowerShell>
     <IsAndroid Condition="$(TargetFramework.ToUpper().Contains('ANDROID'))">true</IsAndroid>
     <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">true</IsIOS>
+    <IsNet6Mac Condition="$(TargetFramework.Contains('-macos'))">true</IsNet6Mac>
   </PropertyGroup>
   <ItemGroup>
   
@@ -63,7 +64,7 @@
   </ItemGroup>
 
   <!-- Xamarin.Mac -->
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND $(RuntimeIdentifiers.Contains('osx-')) != 'true'">
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND '$(IsNet6Mac)' != 'true'">
     <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsPicky.dylib">
       <Kind>Dynamic</Kind>
       <SmartLink>False</SmartLink>


### PR DESCRIPTION
Previous changes made faulty assumptions

On net6-macos; the build system seems capable of picking up the shared libraries from the `runtimes` path _without_ needing to declare them as `NativeReferences`

However, we need to avoid it trying to link the universal shared library used under the Xamarin.Mac target.