### PR TITLE
chore(picky): prepare release (v7.0.0-rc.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "atty"
@@ -90,7 +90,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -106,6 +106,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
@@ -160,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
@@ -178,9 +184,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cab"
@@ -205,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -217,15 +223,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -378,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -390,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -405,15 +411,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,9 +454,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -490,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782e883d0b9a3db55e6edee9939305d0b5c2ee6df793966d84b31144873e5bde"
+checksum = "e62abb876c07e4754fae5c14cafa77937841f01740637e17d78dc04352f32a5e"
 dependencies = [
  "cc",
  "rustc_version",
@@ -503,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -537,42 +543,42 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -651,6 +657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -701,9 +716,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -779,9 +794,9 @@ checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -799,30 +814,33 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "lazy_static"
@@ -844,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "lief-cwal"
@@ -863,7 +881,7 @@ dependencies = [
  "bitflags",
  "image",
  "lief-cwal-sys",
- "picky 7.0.0-rc.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "picky 7.0.0-rc.3",
  "thiserror",
  "widestring 1.0.2",
 ]
@@ -879,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -942,21 +960,21 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -1014,20 +1032,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1042,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -1103,10 +1112,37 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 [[package]]
 name = "picky"
 version = "7.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b467d8082dcc552d4ca8c9aecdc94a09b0e092b961c542bb78b6feff8f1b3ea"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "cab",
+ "chrono",
+ "digest",
+ "md-5",
+ "num-bigint-dig",
+ "oid",
+ "picky-asn1 0.6.0",
+ "picky-asn1-der 0.3.1",
+ "picky-asn1-x509 0.8.0",
+ "rand",
+ "reqwest",
+ "rsa",
+ "serde",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "picky"
+version = "7.0.0-rc.4"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm",
- "base64",
+ "base64 0.13.1",
  "bcrypt-pbkdf",
  "byteorder",
  "cab",
@@ -1136,34 +1172,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror",
- "time 0.3.16",
-]
-
-[[package]]
-name = "picky"
-version = "7.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b467d8082dcc552d4ca8c9aecdc94a09b0e092b961c542bb78b6feff8f1b3ea"
-dependencies = [
- "base64",
- "byteorder",
- "cab",
- "chrono",
- "digest",
- "md-5",
- "num-bigint-dig",
- "oid",
- "picky-asn1 0.6.0",
- "picky-asn1-der 0.3.1",
- "picky-asn1-x509 0.8.0",
- "rand",
- "reqwest",
- "rsa",
- "serde",
- "sha-1",
- "sha2",
- "sha3",
- "thiserror",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -1199,7 +1208,7 @@ dependencies = [
  "picky-asn1-der 0.4.0",
  "serde",
  "serde_bytes",
- "time 0.3.16",
+ "time 0.3.19",
  "zeroize",
 ]
 
@@ -1218,7 +1227,7 @@ dependencies = [
 name = "picky-asn1-der"
 version = "0.4.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "lazy_static",
  "num-bigint-dig",
  "oid",
@@ -1234,7 +1243,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ffcd92e3f788f0f76506f3b86310876cc0014ade835d68a6365ee0fd1009dc"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "num-bigint-dig",
  "oid",
  "picky-asn1 0.6.0",
@@ -1248,7 +1257,7 @@ dependencies = [
 name = "picky-asn1-x509"
 version = "0.9.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hex",
  "num-bigint-dig",
  "oid",
@@ -1269,9 +1278,9 @@ dependencies = [
  "embed-resource",
  "getrandom",
  "hex",
- "picky 7.0.0-rc.3",
+ "picky 7.0.0-rc.4",
  "serde_json",
- "time 0.3.16",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -1302,11 +1311,11 @@ name = "picky-signtool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "clap",
  "encoding_rs",
  "lief-cwal",
- "picky 7.0.0-rc.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "picky 7.0.0-rc.3",
  "walkdir",
 ]
 
@@ -1370,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pretty_assertions"
@@ -1388,18 +1397,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1436,11 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1536,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -1551,39 +1560,39 @@ dependencies = [
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1592,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -1615,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1711,9 +1720,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1722,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -1740,18 +1749,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1760,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1771,12 +1780,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
- "libc",
- "num_threads",
  "serde",
  "time-core",
 ]
@@ -1798,15 +1805,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1816,14 +1823,14 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1835,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -1870,27 +1877,27 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -1936,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "serde",
 ]
@@ -2010,9 +2017,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2020,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -2035,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2047,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2057,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2070,15 +2077,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2143,46 +2150,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 doctest = false
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource = "1.7.2"
+embed-resource = "1.8.0"
 
 [dependencies]
 picky = { path = "../picky/", default-features = false, features = ["ssh", "x509", "time_conversion", "jose"] }
@@ -21,9 +21,9 @@ picky = { path = "../picky/", default-features = false, features = ["ssh", "x509
 diplomat = { git = "https://github.com/CBenoit/diplomat.git", rev = "eee8eb628a61c54883848c1a6e6ba25186708fe2" }
 diplomat-runtime = { git = "https://github.com/CBenoit/diplomat.git", rev = "eee8eb628a61c54883848c1a6e6ba25186708fe2" }
 
-time = "0.3.9"
+time = "0.3.19"
 hex = "0.4.3"
-serde_json = "1.0.82"
+serde_json = "1.0.93"
 
 # WASM support
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ffi/src/x509.rs
+++ b/ffi/src/x509.rs
@@ -83,7 +83,7 @@ pub mod ffi {
 
         pub fn get_subject_key_id_hex(&self, writeable: &mut DiplomatWriteable) -> DiplomatResult<(), Box<PickyError>> {
             let ski = err_check_from!(self.0.subject_key_identifier());
-            let ski = hex::encode(&ski);
+            let ski = hex::encode(ski);
             err_check!(writeable.write_str(&ski));
             writeable.flush();
             Ok(()).into()

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -290,18 +290,18 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -382,7 +382,7 @@ version = "0.4.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",
- "picky 7.0.0-rc.3",
+ "picky 7.0.0-rc.4",
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.3"
+version = "7.0.0-rc.4"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -486,9 +486,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -566,27 +566,27 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest",
  "keccak",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
@@ -666,9 +666,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -677,18 +677,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -18,15 +18,15 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 picky-asn1 = { version = "0.7.0", path = "../picky-asn1" }
-serde = { version = "1.0.136", default-features = false, features = ["derive"] }
-serde_bytes = "0.11.5"
+serde = { version = "1.0.152", default-features = false, features = ["derive"] }
+serde_bytes = "0.11.9"
 lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
-base64 = "0.13.0"
-pretty_assertions = "1.2.1"
-serde_bytes = "0.11.5"
-num-bigint-dig = "0.8.1"
+base64 = "0.13.1"
+pretty_assertions = "1.3.0"
+serde_bytes = "0.11.9"
+num-bigint-dig = "0.8.2"
 oid = { version = "0.2.1", default-features = false, features = ["serde_support"] }
 
 [features]

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -19,16 +19,16 @@ repository = "https://github.com/Devolutions/picky-rs"
 [dependencies]
 picky-asn1 = { version = "0.7", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 oid = { version = "0.2.1", features = ["serde_support"] }
-base64 = "0.13.0"
-num-bigint-dig = { version = "0.8.1", optional = true }
+base64 = "0.13.1"
+num-bigint-dig = { version = "0.8.2", optional = true }
 widestring = { version = "0.5.1", default-features = false, features = ["alloc"], optional = true }
 zeroize = { version = "^1.5", optional = true }
 
 [dev-dependencies]
-num-bigint-dig = "0.8.1"
-pretty_assertions = "1.2.1"
+num-bigint-dig = "0.8.2"
+pretty_assertions = "1.3.0"
 hex = "0.4.3"
 
 [features]

--- a/picky-asn1-x509/src/certificate.rs
+++ b/picky-asn1-x509/src/certificate.rs
@@ -289,11 +289,11 @@ mod tests {
         let cert: Certificate = picky_asn1_der::from_bytes(&encoded).expect("intermediate cert");
 
         pretty_assertions::assert_eq!(
-            hex::encode(&cert.subject_key_identifier().unwrap()),
+            hex::encode(cert.subject_key_identifier().unwrap()),
             "1f74d63f29c17474453b05122c3da8bd435902a6"
         );
         pretty_assertions::assert_eq!(
-            hex::encode(&cert.authority_key_identifier().unwrap().key_identifier().unwrap()),
+            hex::encode(cert.authority_key_identifier().unwrap().key_identifier().unwrap()),
             "b45ae4a5b3ded252f6b9d5a6950feb3ebcc7fdff"
         );
     }

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -15,11 +15,11 @@ repository = "https://github.com/Devolutions/picky-rs"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.136", default-features = false, features = ["derive"] }
+serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 oid = { version = "0.2.1", default-features = false, features = ["serde_support"] }
-serde_bytes = "0.11.5"
-chrono = { version = "0.4.19", optional = true }
-time = { version = "0.3.9", optional = true }
+serde_bytes = "0.11.9"
+chrono = { version = "0.4.23", optional = true }
+time = { version = "0.3.19", optional = true }
 zeroize = { version = "^1.5", optional = true }
 
 [dev-dependencies]

--- a/picky-asn1/src/date.rs
+++ b/picky-asn1/src/date.rs
@@ -354,11 +354,10 @@ mod chrono_convert {
 
     impl<TR: TimeRepr> From<Date<TR>> for NaiveDateTime {
         fn from(date: Date<TR>) -> Self {
-            NaiveDate::from_ymd(i32::from(date.year), u32::from(date.month), u32::from(date.day)).and_hms(
-                u32::from(date.hour),
-                u32::from(date.minute),
-                u32::from(date.second),
-            )
+            NaiveDate::from_ymd_opt(i32::from(date.year), u32::from(date.month), u32::from(date.day))
+                .unwrap()
+                .and_hms_opt(u32::from(date.hour), u32::from(date.minute), u32::from(date.second))
+                .unwrap()
         }
     }
 

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -16,20 +16,20 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 picky-asn1 = { version = "0.7.0", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.4.0", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.9.0", path = "../picky-asn1-x509" }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 byteorder = "1.4.3"
-thiserror = "1.0.30"
+thiserror = "1.0.38"
 
 pbkdf2 = { version = "0.11", features = ["sha1"] }
 hmac = "0.12.1"
-sha1 = "0.10.1"
+sha1 = "0.10.5"
 
 crypto = "0.4.0"
-aes = "0.8.1"
+aes = "0.8.2"
 des = "0.8.1"
 cbc = "0.1.2"
 rand = "0.8.5"
 
-uuid = { version = "1.1.2", default-features = false, features = ["serde"] }
+uuid = { version = "1.3.0", default-features = false, features = ["serde"] }
 oid = "0.2.1"
-num-bigint-dig = { version = "0.8.1", features = ["rand"] }
+num-bigint-dig = { version = "0.8.2", features = ["rand"] }

--- a/picky-krb/src/crypto/checksum.rs
+++ b/picky-krb/src/crypto/checksum.rs
@@ -19,9 +19,9 @@ pub enum ChecksumSuite {
 impl ChecksumSuite {
     pub fn hasher(&self) -> Box<dyn Checksum> {
         match self {
-            ChecksumSuite::HmacSha196Aes256 => Box::new(HmacSha196Aes256::default()),
-            ChecksumSuite::HmacSha196Aes128 => Box::new(HmacSha196Aes128::default()),
-            ChecksumSuite::HmacSha1Des3Kd => Box::new(HmacSha1Des3Kd::default()),
+            ChecksumSuite::HmacSha196Aes256 => Box::<HmacSha196Aes256>::default(),
+            ChecksumSuite::HmacSha196Aes128 => Box::<HmacSha196Aes128>::default(),
+            ChecksumSuite::HmacSha1Des3Kd => Box::<HmacSha1Des3Kd>::default(),
         }
     }
 }

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -7,10 +7,10 @@ description = "A signtool like Authenticode sign and verify tool based on picky 
 publish = false
 
 [dependencies]
-anyhow = "1.0.56"
-clap = "2.33.3"
+anyhow = "1.0.69"
+clap = "2.34.0"
 walkdir = "2.3.2"
-base64 = "0.13.0"
-encoding_rs = "0.8.30"
+base64 = "0.13.1"
+encoding_rs = "0.8.32"
 lief-cwal = "0.1.0"
 picky = { version = "7.0.0-rc.3", default-features = false, features = ["wincert", "ctl", "ctl_http_fetch", "http_timestamp"] }

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -49,10 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support SSH keys and certificates
 - `CheckedJwtEnc::new_with_cty`
 - `CheckedJwtSig::new_with_cty`
+- Support for JWT additional header parameters
 
 ### Changed
 
-- Bump minimal rustc version to 1.56
+- Bump minimal rustc version to 1.60
 - (Breaking) Move Authenticode related code from `picky::x509::wincert` to `picky::x509::pkcs7::authenticode` module
 - (Breaking) Authenticode implementation is now behind `pkcs7` feature
 - (Breaking) `PrivateKey::to_pem` and `PublicKey::to_pem` now return a `Pem`
@@ -61,9 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `BufReader` panic in `WinCertificate::decode` and `WinCertificate::encode` if data len is bigger than default capacity.
-- Fix `WinCertificate` encoding: `length` wasn’t correct.
-- Fix leading zeros in JWK encoding (see issue [#140](https://github.com/Devolutions/picky-rs/issues/140)).
+- `BufReader` panic in `WinCertificate::decode` and `WinCertificate::encode` if data len is bigger than default capacity.
+- `WinCertificate` encoding: `length` wasn’t correct.
+- Leading zeros in JWK encoding.
+
+  JWK encoding of a value is the unsigned big-endian representation as an octet sequence.
+  The octet sequence MUST utilize the minimum number of octets needed to represent the value.
+  That is: **no leading zero** must be present.
+
+  See issue [#140](https://github.com/Devolutions/picky-rs/issues/140)
+
+- Fetch curve info from private_key_algorithm ([#143](https://github.com/Devolutions/picky-rs/issues/143))
+
+  Pick curve info from private_key_algorithm field.
+
 
 ### Removed
 

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "7.0.0-rc.3"
+version = "7.0.0-rc.4"
 authors = [
     "Benoît CORTIER <benoit.cortier@fried-world.eu>",
     "Jonathan Trepanier <jtrepanier@devolutions.net>",
@@ -22,47 +22,47 @@ include = ["src/**/*", "README.md", "CHANGELOG.md"]
 picky-asn1 = { version = "0.7", path = "../picky-asn1", features = ["zeroize"] }
 picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.9", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 oid = { version = "0.2.1", features = ["serde_support"] }
-base64 = "0.13.0"
-thiserror = "1.0.30"
+base64 = "0.13.1"
+thiserror = "1.0.38"
 byteorder = { version = "1.4.3", optional = true }
-chrono = { version = "0.4.19", optional = true }
-time = { version = "0.3.9", optional = true }
-serde_json = { version = "1.0.79", optional = true }
-http = { version = "0.2.6", optional = true }
+chrono = { version = "0.4.23", optional = true }
+time = { version = "0.3.19", optional = true }
+serde_json = { version = "1.0.93", optional = true }
+http = { version = "0.2.9", optional = true }
 cab = { version = "0.3.0", optional = true }
 lexical-sort = { version = "0.3.1", optional = true }
 
 # FIXME: either use ureq, or even better: do not require this kind of dependency at all to let user decide which lib to use.
 # (currently users should *really* not forget to use `spawn_blocking` when calling associated functions from async context)
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking"], optional = true }
+reqwest = { version = "0.11.14", default-features = false, features = ["blocking"], optional = true }
 
 # /!\ ===== cryptography dependencies ===== /!\
 # These should be updated as soon as possible.
 # /!\ ===================================== /!\
 
 rand = "0.8.5"
-num-bigint-dig = "0.8.1"
+num-bigint-dig = "0.8.2"
 
 # Use Ring for now (https://github.com/Devolutions/picky-rs/pull/132#issuecomment-1058224365)
 ring = { version = "0.16.20", optional = true }
 rsa = "0.6.1"
 
-digest = "0.10.3"
-md-5 = "0.10.1"
-sha1 = { package = "sha-1", version = "0.10.0" }
-sha2 = "0.10.2"
-sha3 = "0.10.1"
+digest = "0.10.6"
+md-5 = "0.10.5"
+sha1 = { package = "sha-1", version = "0.10.1" }
+sha2 = "0.10.6"
+sha3 = "0.10.6"
 
 aes-gcm = { version = "0.9.4", optional = true }
-aes = { version = "0.8.1", optional = true }
-ctr = { version = "0.9.1", optional = true }
+aes = { version = "0.8.2", optional = true }
+ctr = { version = "0.9.2", optional = true }
 cbc = { version = "0.1.2", optional = true }
 bcrypt-pbkdf = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"
 hex = "0.4.3"
 cfg-if = "1.0.0"
 ring = "0.16.20"
@@ -87,3 +87,7 @@ http_trait_impl = ["dep:http"]
 chrono_conversion = ["dep:chrono", "picky-asn1/chrono_conversion"]
 time_conversion = ["dep:time", "picky-asn1/time_conversion"]
 ec = ["dep:ring"]
+
+[package.metadata.docs.rs]
+# Enable all features when building documentation for docs.rs
+all-features = true

--- a/picky/src/jose/jwe.rs
+++ b/picky/src/jose/jwe.rs
@@ -457,7 +457,7 @@ enum EncoderMode<'a> {
 
 fn encode_impl(jwe: Jwe, mode: EncoderMode) -> Result<String, JweError> {
     let mut header = jwe.header;
-    let protected_header_base64 = base64::encode_config(&serde_json::to_vec(&header)?, base64::URL_SAFE_NO_PAD);
+    let protected_header_base64 = base64::encode_config(serde_json::to_vec(&header)?, base64::URL_SAFE_NO_PAD);
 
     let (encrypted_key_base64, jwe_cek) = match mode {
         EncoderMode::Direct(symmetric_key) => {
@@ -497,7 +497,7 @@ fn encode_impl(jwe: Jwe, mode: EncoderMode) -> Result<String, JweError> {
             let encrypted_key = rsa_public_key.encrypt(&mut rng, padding, &symmetric_key)?;
 
             (
-                base64::encode_config(&encrypted_key, base64::URL_SAFE_NO_PAD),
+                base64::encode_config(encrypted_key, base64::URL_SAFE_NO_PAD),
                 Cow::Owned(symmetric_key),
             )
         }
@@ -525,7 +525,7 @@ fn encode_impl(jwe: Jwe, mode: EncoderMode) -> Result<String, JweError> {
 
     let initialization_vector_base64 = base64::encode_config(nonce.as_slice(), base64::URL_SAFE_NO_PAD);
     let ciphertext_base64 = base64::encode_config(&buffer, base64::URL_SAFE_NO_PAD);
-    let authentication_tag_base64 = base64::encode_config(&authentication_tag, base64::URL_SAFE_NO_PAD);
+    let authentication_tag_base64 = base64::encode_config(authentication_tag, base64::URL_SAFE_NO_PAD);
 
     Ok([
         protected_header_base64,
@@ -730,7 +730,7 @@ mod tests {
         // 1: JOSE header
 
         let protected_header_base64 =
-            base64::encode_config(&serde_json::to_vec(&jwe.header).unwrap(), base64::URL_SAFE_NO_PAD);
+            base64::encode_config(serde_json::to_vec(&jwe.header).unwrap(), base64::URL_SAFE_NO_PAD);
         assert_eq!(
             protected_header_base64,
             "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ"
@@ -786,7 +786,7 @@ mod tests {
             encrypted_key_base64,
             iv_base64,
             base64::encode_config(&ciphertext, base64::URL_SAFE_NO_PAD),
-            base64::encode_config(&tag, base64::URL_SAFE_NO_PAD),
+            base64::encode_config(tag, base64::URL_SAFE_NO_PAD),
         );
 
         assert_eq!(token, "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ");

--- a/picky/src/jose/jws.rs
+++ b/picky/src/jose/jws.rs
@@ -267,12 +267,12 @@ impl Jws {
     }
 
     pub fn encode(&self, private_key: &PrivateKey) -> Result<String, JwsError> {
-        let header_base64 = base64::encode_config(&serde_json::to_vec(&self.header)?, base64::URL_SAFE_NO_PAD);
+        let header_base64 = base64::encode_config(serde_json::to_vec(&self.header)?, base64::URL_SAFE_NO_PAD);
         let payload_base64 = base64::encode_config(&self.payload, base64::URL_SAFE_NO_PAD);
         let header_and_payload = [header_base64, payload_base64].join(".");
         let signature_algo = SignatureAlgorithm::try_from(self.header.alg)?;
         let signature = signature_algo.sign(header_and_payload.as_bytes(), private_key)?;
-        let signature_base64 = base64::encode_config(&signature, base64::URL_SAFE_NO_PAD);
+        let signature_base64 = base64::encode_config(signature, base64::URL_SAFE_NO_PAD);
         Ok([header_and_payload, signature_base64].join("."))
     }
 

--- a/picky/src/pem.rs
+++ b/picky/src/pem.rs
@@ -133,7 +133,7 @@ fn parse_pem_impl(input: &[u8]) -> Result<Pem<'static>, PemError> {
             .copied()
             .filter(|&byte| byte != b'\r' && byte != b'\n')
             .collect();
-        base64::decode(&striped_raw_data).map_err(|source| PemError::Base64Decoding { source })?
+        base64::decode(striped_raw_data).map_err(|source| PemError::Base64Decoding { source })?
     } else {
         // Can be decoded as is!
         base64::decode(raw_data).map_err(|source| PemError::Base64Decoding { source })?
@@ -173,7 +173,7 @@ pub fn read_pem(reader: &mut impl BufRead) -> Result<Pem<'static>, PemError> {
         .cloned()
         .filter(|&byte| byte != b'\r' && byte != b'\n')
         .collect();
-    let data = base64::decode(&base64_data).map_err(|source| PemError::Base64Decoding { source })?;
+    let data = base64::decode(base64_data).map_err(|source| PemError::Base64Decoding { source })?;
 
     // read until end of footer
     h_read_until(reader, PEM_DASHES_BOUNDARIES.as_bytes(), &mut buf).ok_or(PemError::FooterNotFound)?;

--- a/picky/src/ssh/encode.rs
+++ b/picky/src/ssh/encode.rs
@@ -150,7 +150,7 @@ impl SshComplexTypeEncode for Timestamp {
     type Error = io::Error;
 
     fn encode(&self, mut stream: impl Write) -> Result<(), Self::Error> {
-        stream.write_u64::<BigEndian>(self.0 as u64)?;
+        stream.write_u64::<BigEndian>(self.0)?;
         Ok(())
     }
 }

--- a/picky/src/x509/certificate.rs
+++ b/picky/src/x509/certificate.rs
@@ -109,7 +109,7 @@ pub enum CaChainError {
     IssuerIsNotCA { issuer_id: String },
 
     /// authority key id doesn't match
-    #[error("authority key id doesn't match (expected: {}, got: {})", base64::encode(&.expected), base64::encode(&.actual))]
+    #[error("authority key id doesn't match (expected: {}, got: {})", base64::encode(expected), base64::encode(actual))]
     AuthorityKeyIdMismatch { expected: Vec<u8>, actual: Vec<u8> },
 
     /// issuer name doesn't match
@@ -1063,7 +1063,7 @@ mod tests {
         let key_id = cert
             .subject_key_identifier()
             .expect("couldn't get subject key identifier");
-        pretty_assertions::assert_eq!(hex::encode(&key_id), kid);
+        pretty_assertions::assert_eq!(hex::encode(key_id), kid);
     }
 
     fn parse_key(pem_str: &str) -> PrivateKey {

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -840,7 +840,13 @@ impl<'a> AuthenticodeValidator<'a> {
 
         // In CTL time in a OctetString encoded as 64 bits Windows FILETIME LE
         let time_octet_string_to_utc_time = |time: &OctetStringAsn1| -> DateTime<Utc> {
-            let since: DateTime<Utc> = DateTime::from_utc(NaiveDate::from_ymd(1601, 1, 1).and_hms(0, 0, 0), Utc);
+            let since: DateTime<Utc> = DateTime::from_utc(
+                NaiveDate::from_ymd_opt(1601, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap(),
+                Utc,
+            );
             since.add(Duration::seconds(
                 i64::from_le_bytes([
                     time.0[0], time.0[1], time.0[2], time.0[3], time.0[4], time.0[5], time.0[6], time.0[7],

--- a/picky/src/x509/wincert.rs
+++ b/picky/src/x509/wincert.rs
@@ -84,7 +84,7 @@ impl WinCertificate {
         buffer.write_u16::<LittleEndian>(certificate_type as u16)?;
 
         buffer.write_all(&certificate)?;
-        buffer.write_all(&vec![0; padding as usize])?;
+        buffer.write_all(&vec![0; padding])?;
 
         buffer
             .into_inner()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.67.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
General maintenance of the project and preparing publication of the next release candidate of `picky` crate (`v7.0.0.rc-4`).
Enable all features when generating documentation on docs.rs (see https://github.com/Devolutions/picky-rs/issues/203#issuecomment-1436117513)