### PR TITLE
Serialize and deserialize RSASSA-PSS AlgorithmIdentifier.

### DIFF
--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -3,6 +3,9 @@ use oid::ObjectIdentifier;
 use picky_asn1::tag::{Tag, TagPeeker};
 use picky_asn1::wrapper::{IntegerAsn1, ObjectIdentifierAsn1, OctetStringAsn1};
 use serde::{de, ser, Deserialize, Serialize};
+use picky_asn1::wrapper::ExplicitContextTag0;
+use picky_asn1::wrapper::ExplicitContextTag1;
+use picky_asn1::wrapper::ExplicitContextTag2;
 use std::error::Error;
 use std::fmt;
 
@@ -103,6 +106,13 @@ impl AlgorithmIdentifier {
         Self {
             algorithm: oids::id_rsassa_pkcs1_v1_5_with_sha3_512().into(),
             parameters: AlgorithmIdentifierParameters::Null,
+        }
+    }
+
+    pub fn new_rsassa_pss(parameters: RsassaPssParams) -> Self {
+        Self {
+            algorithm: oids::rsassa_pss().into(),
+            parameters: AlgorithmIdentifierParameters::RsassaPss(parameters),
         }
     }
 
@@ -224,6 +234,9 @@ impl ser::Serialize for AlgorithmIdentifier {
             AlgorithmIdentifierParameters::Aes(aes_params) => {
                 seq.serialize_element(aes_params)?;
             }
+            AlgorithmIdentifierParameters::RsassaPss(rsa_params) => {
+                seq.serialize_element(rsa_params)?;
+            }
         }
         seq.end()
     }
@@ -263,6 +276,11 @@ impl<'de> de::Deserialize<'de> for AlgorithmIdentifier {
                         let _ = seq.next_element::<()>();
                         AlgorithmIdentifierParameters::Null
                     }
+                    oids::RSASSA_PSS => AlgorithmIdentifierParameters::RsassaPss(seq_next_element!(
+                        seq,
+                        RsassaPssParams,
+                        "RSASSA-PSS parameters"
+                    )),
                     oids::ECDSA_WITH_SHA384 | oids::ECDSA_WITH_SHA256 | oids::ECDSA_WITH_SHA512 | oids::ED25519 => {
                         AlgorithmIdentifierParameters::None
                     }
@@ -315,6 +333,259 @@ pub enum AlgorithmIdentifierParameters {
     Null,
     Aes(AesParameters),
     Ec(Option<EcParameters>),
+    RsassaPss(RsassaPssParams),
+}
+
+/// [RFC 4055 #3.1](https://www.rfc-editor.org/rfc/rfc4055#section-3.1)
+///
+/// ```not_rust
+///       RSASSA-PSS-params  ::=  SEQUENCE  {
+///           hashAlgorithm      [0] HashAlgorithm DEFAULT
+///                                     sha1Identifier,
+///           maskGenAlgorithm   [1] MaskGenAlgorithm DEFAULT
+///                                     mgf1SHA1Identifier,
+///           saltLength         [2] INTEGER DEFAULT 20,
+///           trailerField       [3] INTEGER DEFAULT 1  }
+/// ```
+///
+/// Implementations that perform signature generation MUST omit the trailerField
+/// field, indicating that the default trailer field value was used... thus the
+/// reason no trailer field is specified in this structure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RsassaPssParams {
+    pub hash_algorithm: HashAlgorithm,
+    pub mask_gen_algorithm: MaskGenAlgorithm,
+    pub salt_length: usize,
+}
+
+impl RsassaPssParams {
+    pub fn new(hash_algorithm: HashAlgorithm) -> Self {
+        Self {
+            hash_algorithm,
+            mask_gen_algorithm: MaskGenAlgorithm::new(hash_algorithm),
+            salt_length: hash_algorithm.len(),
+        }
+    }
+}
+
+impl ser::Serialize for RsassaPssParams {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, <S as ser::Serializer>::Error>
+    where
+        S: ser::Serializer,
+    {
+        use ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(3))?;
+        seq.serialize_element(&ExplicitContextTag0(&self.hash_algorithm))?;
+        seq.serialize_element(&ExplicitContextTag1(&self.mask_gen_algorithm))?;
+        seq.serialize_element(&ExplicitContextTag2(&IntegerAsn1::from_bytes_be_signed(self.salt_length.to_be_bytes().to_vec())))?;
+        seq.end()
+    }
+}
+
+fn usize_from_be_bytes(asn1: &IntegerAsn1) -> usize {
+    let bytes = asn1.as_unsigned_bytes_be();
+    if bytes.len() > 8 {
+        usize::MAX
+    } else if bytes.len() < 8 {
+        let mut tmp = [0; 8];
+        tmp[(8 - bytes.len())..8].clone_from_slice(bytes);
+        usize::from_be_bytes(tmp)
+    } else {
+        // unwrap is safe since we know this is exactly 8 bytes.
+        usize::from_be_bytes(bytes.try_into().unwrap())
+    }
+}
+
+impl<'de> de::Deserialize<'de> for RsassaPssParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as de::Deserializer<'de>>::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = RsassaPssParams;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid DER-encoded RsassaPssParams")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let hash = seq_next_element!(seq, ExplicitContextTag0<HashAlgorithm>, HashAlgorithm, "cont [0]");
+                let mask_gen = seq_next_element!(seq, ExplicitContextTag1<MaskGenAlgorithm>, MaskGenAlgorithm, "maskGenAlgorithm");
+                let salt = seq_next_element!(seq, ExplicitContextTag2<IntegerAsn1>, IntegerAsn1, "saltLength");
+                Ok(RsassaPssParams {
+                    hash_algorithm: hash.0,
+                    mask_gen_algorithm: mask_gen.0,
+                    salt_length: usize_from_be_bytes(&salt.0),
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
+}
+
+// https://www.rfc-editor.org/rfc/rfc4055#section-2.1
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum HashAlgorithm {
+    // Nobody should be using SHA1 in 2023, it is completely broken... and the RFC for RsassaPssParams
+    // adds needless complexity in regard to requiring the omission of parameters if SHA1 is used.
+    //SHA1,
+    SHA224,
+    SHA256,
+    SHA384,
+    SHA512,
+}
+
+impl HashAlgorithm {
+    pub fn len(&self) -> usize {
+        use HashAlgorithm::*;
+        match self {
+            //SHA1 => 20,
+            SHA224 => 28,
+            SHA256 => 32,
+            SHA384 => 48,
+            SHA512 => 64,
+        }
+    }
+}
+impl From<&HashAlgorithm> for ObjectIdentifierAsn1 {
+    fn from(variant: &HashAlgorithm) -> Self {
+        use HashAlgorithm::*;
+        match variant {
+            //SHA1 => oids::sha1().into(),
+            SHA224 => oids::sha224().into(),
+            SHA256 => oids::sha256().into(),
+            SHA384 => oids::sha384().into(),
+            SHA512 => oids::sha512().into(),
+        }
+    }
+}
+
+impl TryFrom<ObjectIdentifierAsn1> for HashAlgorithm {
+    type Error = UnsupportedAlgorithmError;
+
+    fn try_from(oid: ObjectIdentifierAsn1) -> Result<Self, Self::Error> {
+        match Into::<String>::into(oid.0).as_str() {
+            //oids::SHA1 => Ok(HashAlgorithm::SHA1),
+            oids::SHA224 => Ok(HashAlgorithm::SHA224),
+            oids::SHA256 => Ok(HashAlgorithm::SHA256),
+            oids::SHA384 => Ok(HashAlgorithm::SHA384),
+            oids::SHA512 => Ok(HashAlgorithm::SHA512),
+            unsupported => Err(UnsupportedAlgorithmError {
+                algorithm: unsupported.to_string(),
+            }),
+        }
+    }
+}
+
+impl ser::Serialize for HashAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, <S as ser::Serializer>::Error>
+    where
+        S: ser::Serializer,
+    {
+        use ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&ObjectIdentifierAsn1::from(self))?;
+        seq.serialize_element(&())?;
+        seq.end()
+    }
+}
+
+impl<'de> de::Deserialize<'de> for HashAlgorithm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as de::Deserializer<'de>>::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = HashAlgorithm;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid DER-encoded HashAlgorithm")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let oid: ObjectIdentifierAsn1 = seq_next_element!(seq, ObjectIdentifierAsn1, "oid of hashAlgorithm");
+                let _: Option<()> = seq.next_element()?;
+                oid.try_into().map_err(|_| serde_invalid_value!(
+                    HashAlgorithm,
+                    "unsupported or unknown hash algorithm",
+                    "a supported hash algorithm"
+                ))
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaskGenAlgorithm {
+    pub mask_gen_algorithm: ObjectIdentifierAsn1,
+    pub hash_algorithm: HashAlgorithm,
+}
+
+impl MaskGenAlgorithm {
+    pub fn new(hash_algorithm: HashAlgorithm) -> Self {
+        Self {
+            mask_gen_algorithm: ObjectIdentifierAsn1::from(oids::id_mgf1()),
+            hash_algorithm,
+        }
+    }
+}
+
+impl ser::Serialize for MaskGenAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as ser::Serializer>::Ok, <S as ser::Serializer>::Error>
+    where
+        S: ser::Serializer,
+    {
+        use ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&self.mask_gen_algorithm)?;
+        seq.serialize_element(&self.hash_algorithm)?;
+        seq.end()
+    }
+}
+
+impl<'de> de::Deserialize<'de> for MaskGenAlgorithm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as de::Deserializer<'de>>::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = MaskGenAlgorithm;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid DER-encoded MaskGenAlgorithm")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let mask_gen_algorithm: ObjectIdentifierAsn1 = seq_next_element!(seq, ObjectIdentifierAsn1, "oid of maskGenAlgorithm");
+                let hash_algorithm: HashAlgorithm = seq_next_element!(seq, HashAlgorithm, "hashAlgorithm");
+                Ok(MaskGenAlgorithm {
+                    mask_gen_algorithm,
+                    hash_algorithm,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -677,6 +948,52 @@ mod tests {
         ];
 
         assert_eq!(digest, expected);
+    }
+
+
+    #[test]
+    fn rsa_pss_params_sha256() {
+        let expected = [
+            0x30, 0x34, 0xa0, 0x0f, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
+            0x00, 0xa1, 0x1c, 0x30, 0x1a, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x08, 0x30, 0x0d,
+            0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0xa2, 0x03, 0x02, 0x01, 0x20
+        ];
+        let structure = RsassaPssParams::new(HashAlgorithm::SHA256);
+        check_serde!(structure: RsassaPssParams in expected);
+    }
+
+    #[test]
+    fn rsa_pss_params_sha384() {
+        let expected = [
+            0x30, 0x34, 0xa0, 0x0f, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05,
+            0x00, 0xa1, 0x1c, 0x30, 0x1a, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x08, 0x30, 0x0d,
+            0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0xa2, 0x03, 0x02, 0x01, 0x30
+        ];
+        let structure = RsassaPssParams::new(HashAlgorithm::SHA384);
+        check_serde!(structure: RsassaPssParams in expected);
+    }
+
+    #[test]
+    fn rsa_pss_params_sha512() {
+        let expected = [
+            0x30, 0x34, 0xa0, 0x0f, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
+            0x00, 0xa1, 0x1c, 0x30, 0x1a, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x08, 0x30, 0x0d,
+            0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0xa2, 0x03, 0x02, 0x01, 0x40
+        ];
+        let structure = RsassaPssParams::new(HashAlgorithm::SHA512);
+        check_serde!(structure: RsassaPssParams in expected);
+    }
+
+    #[test]
+    fn rsa_pss_encryption() {
+        let expected = [
+            0x30, 0x41, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0A, 0x30, 0x34, 0xa0, 0x0f, 0x30,
+            0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0xa1, 0x1c, 0x30, 0x1a,
+            0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x08, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48,
+            0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0xa2, 0x03, 0x02, 0x01, 0x20
+        ];
+        let structure = AlgorithmIdentifier::new_rsassa_pss(RsassaPssParams::new(HashAlgorithm::SHA256));
+        check_serde!(structure: AlgorithmIdentifier in expected);
     }
 
     #[test]

--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -60,6 +60,7 @@ define_oid! {
     SHA384_WITH_RSA_ENCRYPTION => sha384_with_rsa_encryption => "1.2.840.113549.1.1.12",
     SHA512_WITH_RSA_ENCRYPTION => sha512_with_rsa_encryption => "1.2.840.113549.1.1.13",
     SHA224_WITH_RSA_ENCRYPTION => sha224_with_rsa_encryption => "1.2.840.113549.1.1.14",
+    RSASSA_PSS => rsassa_pss => "1.2.840.113549.1.1.10",
     EMAIL_ADDRESS => email_address => "1.2.840.113549.1.9.1", // deprecated
     EXTENSION_REQ => extension_request => "1.2.840.113549.1.9.14",
 
@@ -210,6 +211,9 @@ define_oid! {
     UNKNOWN_RESERVED_PROP_ID_127 => unknown_reserved_prop_id_127 => "1.3.6.1.4.1.311.10.11.127",
 
     AUTO_UPDATE_END_REVOCATION => auto_update_end_revocation => "1.3.6.1.4.1.311.60.3.2",
+
+    // RSA  Mask Generator Function 1
+    ID_MGF1 => id_mgf1 => "1.2.840.113549.1.1.8",
 
     // NLA protocols
     KRB5 => krb5 => "1.2.840.113554.1.2.2",


### PR DESCRIPTION
Note that the deserializer assumes all fields are specified in the ASN.1 structure and none are using the default. Given that SHA1 is considered broken, and that all default fields only make sense in the context of SHA1, no effort has been made to support the DEFAULTs.