### PR TITLE
Update base64 to version 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ version = "7.0.0-rc.5"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bcrypt-pbkdf",
  "byteorder",
  "cab",
@@ -1361,7 +1361,7 @@ dependencies = [
 name = "picky-asn1-der"
 version = "0.4.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "lazy_static",
  "num-bigint-dig",
  "oid",
@@ -1391,7 +1391,7 @@ dependencies = [
 name = "picky-asn1-x509"
 version = "0.9.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "hex",
  "num-bigint-dig",
  "oid",
@@ -1445,7 +1445,7 @@ name = "picky-signtool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.0",
  "clap",
  "encoding_rs",
  "lief-cwal",

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -23,7 +23,7 @@ serde_bytes = "0.11.9"
 lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
-base64 = "0.13.1"
+base64 = "0.21"
 pretty_assertions = "1.3.0"
 serde_bytes = "0.11.9"
 num-bigint-dig = "0.8.2"

--- a/picky-asn1-der/tests/pki_tests/ocsp_request.rs
+++ b/picky-asn1-der/tests/pki_tests/ocsp_request.rs
@@ -39,6 +39,7 @@
 // https://access.redhat.com/documentation/en-us/red_hat_certificate_system/9/html/administration_guide/online_certificate_status_protocol_responder
 // https://lapo.it/asn1js/#MEIwQDA-MDwwOjAJBgUrDgMCGgUABBT4cyABkyiCIhU4JpmIBewdDnn8ZgQUbyBZ44kgy35o7xW5BMzM8FTvyTwCAQE
 
+use base64::{engine::general_purpose, Engine as _};
 use oid::prelude::*;
 use picky_asn1::wrapper::{ObjectIdentifierAsn1, OctetStringAsn1};
 use serde::{Deserialize, Serialize};
@@ -74,11 +75,12 @@ pub struct AlgorithmIdentifier {
 
 #[test]
 fn ocsp_request() {
-    let encoded_ocsp_request = base64::decode(
-        "MEIwQDA+MDwwOjAJBgUrDgMCGgUABBT4cyABkyiCIhU4J\
+    let encoded_ocsp_request = general_purpose::STANDARD
+        .decode(
+            "MEIwQDA+MDwwOjAJBgUrDgMCGgUABBT4cyABkyiCIhU4J\
          pmIBewdDnn8ZgQUbyBZ44kgy35o7xW5BMzM8FTvyTwCAQE=",
-    )
-    .expect("invalid base64");
+        )
+        .expect("invalid base64");
 
     let sha1_oid = ObjectIdentifier::try_from("1.3.14.3.2.26").unwrap();
     let ocsp_request = OcspRequest {

--- a/picky-asn1-der/tests/pki_tests/rsa_public_key.rs
+++ b/picky-asn1-der/tests/pki_tests/rsa_public_key.rs
@@ -15,6 +15,7 @@
 // https://lapo.it/asn1js/#MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiLoIxmXaZAFRBKtHYZhiF8m-pYR-xGIpupvsdDEvKO92D6fIccgVLIW6p6sSNkoXx5J6KDSMbA_chy5M6pRvJkaCXCI4zlCPMYvPhI8OxN3RYPfdQTLpgPywrlfdn2CAum7o4D8nR4NJacB3NfPnS9tsJ2L3p5iHviuTB4xm03IKmPPqsaJy-nXUFC1XS9E_PseVHRuNvKa7WmlwSZngQzKAVSIwqpgCc-oP1pKEeJ0M3LHFo8ao5SuzhfXUIGrPnkUKEE3m7B0b8xXZfP1N6ELoonWDK-RMgYIBaZdgBhPfHxF8KfTHvSzcUzWZojuR-ynaFL9AJK-8RiXnB4CJwIDAQAB
 
 use super::ocsp_request::AlgorithmIdentifier;
+use base64::{engine::general_purpose, Engine as _};
 use num_bigint_dig::BigInt;
 use oid::prelude::*;
 use picky_asn1::wrapper::*;
@@ -35,16 +36,17 @@ type EncapsulatedRSAPublicKey = BitStringAsn1Container<RSAPublicKey>;
 
 #[test]
 fn subject_public_key_info() {
-    let encoded = base64::decode(
-        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiLoIx\
+    let encoded = general_purpose::STANDARD
+        .decode(
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiLoIx\
          mXaZAFRBKtHYZhiF8m+pYR+xGIpupvsdDEvKO92D6fIccgVLIW6p6sSNk\
          oXx5J6KDSMbA/chy5M6pRvJkaCXCI4zlCPMYvPhI8OxN3RYPfdQTLpgPy\
          wrlfdn2CAum7o4D8nR4NJacB3NfPnS9tsJ2L3p5iHviuTB4xm03IKmPPq\
          saJy+nXUFC1XS9E/PseVHRuNvKa7WmlwSZngQzKAVSIwqpgCc+oP1pKEe\
          J0M3LHFo8ao5SuzhfXUIGrPnkUKEE3m7B0b8xXZfP1N6ELoonWDK+RMgY\
          IBaZdgBhPfHxF8KfTHvSzcUzWZojuR+ynaFL9AJK+8RiXnB4CJwIDAQAB",
-    )
-    .expect("invalid base64");
+        )
+        .expect("invalid base64");
 
     // RSA algorithm identifier
 

--- a/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
+++ b/picky-asn1-der/tests/pki_tests/x509_v3_certificate.rs
@@ -57,6 +57,7 @@
 use crate::pki_tests::ocsp_request::AlgorithmIdentifier;
 use crate::pki_tests::rsa_public_key::{RSAPublicKey, SubjectPublicKeyInfoRsa};
 use crate::pki_tests::version::{implicit_app0_version_is_default, Version};
+use base64::{engine::general_purpose, Engine as _};
 use num_bigint_dig::BigInt;
 use oid::prelude::*;
 use picky_asn1::bit_string::BitString;
@@ -113,8 +114,9 @@ struct Extension {
 
 #[test]
 fn x509_v3_certificate() {
-    let encoded = base64::decode(
-        "MIIEGjCCAgKgAwIBAgIEN8NXxDANBgkqhkiG9w0BAQsFADAiMSAwHgYDVQQ\
+    let encoded = general_purpose::STANDARD
+        .decode(
+            "MIIEGjCCAgKgAwIBAgIEN8NXxDANBgkqhkiG9w0BAQsFADAiMSAwHgYDVQQ\
          DDBdjb250b3NvLmxvY2FsIEF1dGhvcml0eTAeFw0xOTEwMTcxNzQxMjhaFw0yMjEwM\
          TYxNzQxMjhaMB0xGzAZBgNVBAMMEnRlc3QuY29udG9zby5sb2NhbDCCASIwDQYJKoZ\
          IhvcNAQEBBQADggEPADCCAQoCggEBAMptALdk7xKj9JmFSycxlaTV47oLv5Aabir17\
@@ -136,8 +138,8 @@ fn x509_v3_certificate() {
          yNp7WjRYl8hJ0YVZ7TRtP8nJOkZ6s046YHVWxMuGdqZfd/AUFb9xzzXjGRuuZ1JmSf\
          +VBOFEe2MaPMyMQBeIs3Othz6Fcy6Am5F6c3It31WYJwiCa/NdbMIvGy1xvAN5kzR/\
          Y6hkoQljoSr1rVuszJ9dtvuTccA==",
-    )
-    .expect("invalid base64");
+        )
+        .expect("invalid base64");
 
     // Issuer
 

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -21,7 +21,7 @@ picky-asn1 = { version = "0.7", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
 serde = { version = "1.0.152", features = ["derive"] }
 oid = { version = "0.2.1", features = ["serde_support"] }
-base64 = "0.13.1"
+base64 = "0.21"
 num-bigint-dig = { version = "0.8.2", optional = true }
 widestring = { version = "0.5.1", default-features = false, features = ["alloc"], optional = true }
 zeroize = { version = "^1.5", optional = true }

--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -605,6 +605,7 @@ pub struct DigestInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
 
     #[test]
     fn aes_null_params() {

--- a/picky-asn1-x509/src/certificate.rs
+++ b/picky-asn1-x509/src/certificate.rs
@@ -161,14 +161,16 @@ fn extensions_are_empty(extensions: &Extensions) -> bool {
 mod tests {
     use super::*;
     use crate::{DirectoryName, Extension, KeyIdentifier, KeyUsage};
+    use base64::{engine::general_purpose, Engine as _};
     use num_bigint_dig::BigInt;
     use picky_asn1::bit_string::BitString;
     use picky_asn1::date::UTCTime;
 
     #[test]
     fn x509_v3_certificate() {
-        let encoded = base64::decode(
-            "MIIEGjCCAgKgAwIBAgIEN8NXxDANBgkqhkiG9w0BAQsFADAiMSAwHgYDVQQ\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIIEGjCCAgKgAwIBAgIEN8NXxDANBgkqhkiG9w0BAQsFADAiMSAwHgYDVQQ\
              DDBdjb250b3NvLmxvY2FsIEF1dGhvcml0eTAeFw0xOTEwMTcxNzQxMjhaFw0yMjEwM\
              TYxNzQxMjhaMB0xGzAZBgNVBAMMEnRlc3QuY29udG9zby5sb2NhbDCCASIwDQYJKoZ\
              IhvcNAQEBBQADggEPADCCAQoCggEBAMptALdk7xKj9JmFSycxlaTV47oLv5Aabir17\
@@ -190,8 +192,8 @@ mod tests {
              yNp7WjRYl8hJ0YVZ7TRtP8nJOkZ6s046YHVWxMuGdqZfd/AUFb9xzzXjGRuuZ1JmSf\
              +VBOFEe2MaPMyMQBeIs3Othz6Fcy6Am5F6c3It31WYJwiCa/NdbMIvGy1xvAN5kzR/\
              Y6hkoQljoSr1rVuszJ9dtvuTccA==",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         // Issuer
 
@@ -264,8 +266,9 @@ mod tests {
 
     #[test]
     fn key_id() {
-        let encoded = base64::decode(
-            "MIIDPzCCAiegAwIBAgIBATANBgkqhkiG9w0BAQUFADA7MQswCQYDVQQGEwJOTDER\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIIDPzCCAiegAwIBAgIBATANBgkqhkiG9w0BAQUFADA7MQswCQYDVQQGEwJOTDER\
                 MA8GA1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwHhcN\
                 MTEwMjEyMTQ0NDA2WhcNMjEwMjEyMTQ0NDA2WjA8MQswCQYDVQQGEwJOTDERMA8G\
                 A1UECgwIUG9sYXJTU0wxGjAYBgNVBAMMEVBvbGFyU1NMIFNlcnZlciAxMIIBIjAN\
@@ -283,8 +286,8 @@ mod tests {
                 jvo3oVjiexfasjsICXFNoncjthKtS7v4zrsgXNPz92h58NgXnDtQU+Eb9tVA9kUs\
                 Ln/az3v5DdgrNoAO60zK1zYAmekLil7pgba/jBLPeAQ2fZVgFxttKv33nUnUBzKA\
                 Od8i323fM5dQS1qQpBjBc/5fPw==",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         let cert: Certificate = picky_asn1_der::from_bytes(&encoded).expect("intermediate cert");
 

--- a/picky-asn1-x509/src/certification_request.rs
+++ b/picky-asn1-x509/src/certification_request.rs
@@ -114,6 +114,7 @@ mod tests {
     use super::*;
     use crate::name::*;
     use crate::{DirectoryName, Extension, GeneralName};
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::bit_string::BitString;
     use picky_asn1::restricted_string::{IA5String, PrintableString, Utf8String};
     use picky_asn1::wrapper::IntegerAsn1;
@@ -121,8 +122,9 @@ mod tests {
 
     #[test]
     fn basic_csr() {
-        let encoded = base64::decode(
-            "MIICYjCCAUoCAQAwHTEbMBkGA1UEAxMSdGVzdC5jb250b3NvLmxvY2FsMIIBIjAN\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIICYjCCAUoCAQAwHTEbMBkGA1UEAxMSdGVzdC5jb250b3NvLmxvY2FsMIIBIjAN\
             BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAym0At2TvEqP0mYVLJzGVpNXjugu/\
             kBpuKvXt/Vax4Bxnj3YzHTCpwkyZPytUC6zJ+q+uGh0e7gYQsYHJKjgoKEsS6gQ4\
             ZM3D/AQy0zqPUT0ruSKDWKK4f2d/2ijDs5R2LHj7DtNZBanCXU16Qp1O28su0QZK\
@@ -135,8 +137,8 @@ mod tests {
             6OK9O6ypqTtwXxnm3TJF9dctLwvbh7NZSaamSlxI0/ajKZOP9k1KZEOPtaiiMPe2\
             yr+QvwY2ov66MRG5PPRZELQWBaPZOuFwmCsFOLXJMpvhoAgklBCFZmiQMgApGIC1\
             FIDgjm2ZhQQIRMnTsAV6f7BclRTaUkc0sPl17YB9GfNfOm1oL7o=",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         let certification_request_info = CertificationRequestInfo::new(
             DirectoryName::new_common_name(PrintableString::from_str("test.contoso.local").unwrap()),
@@ -159,8 +161,9 @@ mod tests {
 
     #[test]
     fn csr_with_extensions_attribute() {
-        let encoded = base64::decode(
-            "MIICjDCCAXQCAQAwIDELMAkGA1UEBhMCWFgxETAPBgNVBAMMCHNvbWV0ZXN0MIIB\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIICjDCCAXQCAQAwIDELMAkGA1UEBhMCWFgxETAPBgNVBAMMCHNvbWV0ZXN0MIIB\
             IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvNELh212N4optYS7pqbtvjyv\
             +t4fQjX/pwB88BUCEjBgh+DJ49EBPQg9oObADTcBi3EeXu4M5y6f/dzIhovayJ/y\
             9j7Cj0Bw+VY+eRXywkVG/DqaiKG2mIQW+fho7/jhazhpeIxCzObPTwiQK7i96Vjq\
@@ -174,8 +177,8 @@ mod tests {
             cd6xK4oIJyoeiXyVBdn68gtPY6xjFxta67nyj39sSGhATxrDgxtLHEH2+HStywr0\
             4/osg9vP/OH5iFYOiEimK6ErYNg8rM1A/OTe5p8emA6y3o5dHG8lKYwevyUXMSLv\
             38CNeh0MS2KmyHz2085HlIIAXIu2xAUyWLsQik+eV6M=",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         let extensions = vec![Extension::new_subject_alt_name(vec![GeneralName::DnsName(
             IA5String::from_string("localhost".into()).unwrap().into(),

--- a/picky-asn1-x509/src/extension.rs
+++ b/picky-asn1-x509/src/extension.rs
@@ -529,6 +529,7 @@ impl ExtendedKeyUsage {
 mod tests {
     use super::*;
     use crate::GeneralName;
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::restricted_string::IA5String;
 
     #[test]
@@ -543,8 +544,9 @@ mod tests {
 
     #[test]
     fn eku_ku_bc_san_extensions() {
-        let cert_der = base64::decode(
-            "MIIDIjCCAgoCAQAwIDELMAkGA1UEBhMCRlIxETAPBgNVBAMMCERyYXBlYXUhMIIB\
+        let cert_der = general_purpose::STANDARD
+            .decode(
+                "MIIDIjCCAgoCAQAwIDELMAkGA1UEBhMCRlIxETAPBgNVBAMMCERyYXBlYXUhMIIB\
                            IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5GqDEM7AfctJizsFEqtAvXd5\
                            Fl1GtyXDAnx68MUTuSL22t8aBZoCCi3/9AlS75uUqKggHnRuY2MRYPQaUzpE1F1a\
                            aZJNr6tXQy39FtdXrDq2zfwZdDmLW6sPmhvJrBO4yWjuG3wh1paPHy+rBHOjYt+9\
@@ -561,8 +563,8 @@ mod tests {
                            VDWhWaGncSdDur6++dp2OAGYTAv4XIHc0nhtcBoxeL4VhjcuksOdGg3JF02gW6Rc\
                            B1gipqD0jun8kPgWcQY22zhmP2HuPp0y58t9cu9FsnUcAFa//5pQA1LuaSFp65D4\
                            92uaByS3lH18xzrkygzn1BeHRpo0fk4I9Rk8uy2QygCk43Pv6SU=",
-        )
-        .expect("cert der");
+            )
+            .expect("cert der");
 
         let encoded = &cert_der[359..359 + 3 + 168];
 

--- a/picky-asn1-x509/src/macros.rs
+++ b/picky-asn1-x509/src/macros.rs
@@ -39,7 +39,7 @@ mod tests {
         };
         ($item:ident: $type:ident in $encoded:ident) => {
             let encoded = &$encoded[..];
-            let encoded_base64 = base64::encode(encoded);
+            let encoded_base64 = general_purpose::STANDARD.encode(encoded);
 
             println!(concat!(stringify!($item), " check..."));
 
@@ -48,7 +48,7 @@ mod tests {
                 stringify!($item),
                 " serialization"
             ));
-            let serialized_base64 = base64::encode(&serialized);
+            let serialized_base64 = general_purpose::STANDARD.encode(&serialized);
             pretty_assertions::assert_eq!(
                 serialized_base64, encoded_base64,
                 concat!("serialized ", stringify!($item), " doesn't match")

--- a/picky-asn1-x509/src/name.rs
+++ b/picky-asn1-x509/src/name.rs
@@ -382,6 +382,7 @@ pub struct EdiPartyName {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
     use oid::ObjectIdentifier;
     use picky_asn1::restricted_string::IA5String;
     use picky_asn1_der::Asn1RawDer;

--- a/picky-asn1-x509/src/pkcs7.rs
+++ b/picky-asn1-x509/src/pkcs7.rs
@@ -66,12 +66,14 @@ mod tests {
     use super::Pkcs7Certificate;
     use crate::pkcs7::signer_info::UnsignedAttributeValue;
     use crate::{Attribute, AttributeValues};
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::wrapper::{Asn1SetOf, OctetStringAsn1};
 
     #[test]
     fn full_pkcs7_decode() {
-        let decoded = base64::decode(
-            "MIIF1AYJKoZIhvcNAQcCoIIFxTCCBcECAQExADALBgkqhkiG9w0BBwGgggWnMIIF\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIF1AYJKoZIhvcNAQcCoIIFxTCCBcECAQExADALBgkqhkiG9w0BBwGgggWnMIIF\
                 ozCCA4ugAwIBAgIUXp0J4CZ0ZSsXBh952AQo0XUudpwwDQYJKoZIhvcNAQELBQAw\
                 YTELMAkGA1UEBhMCQVIxCzAJBgNVBAgMAkFSMQswCQYDVQQHDAJBUjELMAkGA1UE\
                 CgwCQVIxCzAJBgNVBAsMAkFSMQswCQYDVQQDDAJBUjERMA8GCSqGSIb3DQEJARYC\
@@ -103,8 +105,8 @@ mod tests {
                 Eh49eilHGchkyMBawo80ctWy9UNH/Yt3uiwuga0Q2sCLlrbPxE5Ro3Ou/SZF9YtZ\
                 Ee/Xdsl0pUmdAylBzp08AJWCuPheE7XjrnfDlPz4BRuiB+qOMDO/ngLNZ0rFbiIV\
                 3ojRzKEAMQA=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let pkcs7: Pkcs7Certificate = picky_asn1_der::from_bytes(decoded.as_slice()).unwrap();
         check_serde!(pkcs7: Pkcs7Certificate in decoded);
@@ -112,8 +114,9 @@ mod tests {
 
     #[test]
     fn full_pkcs7_decode_with_ca_root() {
-        let decoded = base64::decode(
-            "MIIIwgYJKoZIhvcNAQcCoIIIszCCCK8CAQExADALBgkqhkiG9w0BBwGgggiVMIIE\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIIwgYJKoZIhvcNAQcCoIIIszCCCK8CAQExADALBgkqhkiG9w0BBwGgggiVMIIE\
                 nDCCAoQCFGe148Dqygm4BCpH70eVHP64Kf3zMA0GCSqGSIb3DQEBCwUAMIGHMQsw\
                 CQYDVQQGEwJUWTELMAkGA1UECAwCVFkxETAPBgNVBAcMCFNvbWVDaXR5MRQwEgYD\
                 VQQKDAtTb21lQ29tcGFueTERMA8GA1UECwwIU29tZVVuaXQxDzANBgNVBAMMBk15\
@@ -160,8 +163,8 @@ mod tests {
                 5UPxb2USETPoTohJOPpE27w6/1Ztb8AUgDzjZwd50Ty1ci6SBeFsD7YBgnSZO9ze\
                 S8zhKeY18ivsny0RKPO28/fO7rhExogn4sg12H6kaM3NokmDUf8FVy/Np0LCFreU\
                 cjZ0Bdoi73yZiQcNp8lb1Hm5jJbq2Oa1aY88KZ1Hdyx+jqEAMQA=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let pkcs7: Pkcs7Certificate = picky_asn1_der::from_bytes(decoded.as_slice()).unwrap();
         check_serde!(pkcs7: Pkcs7Certificate in decoded);
@@ -169,8 +172,9 @@ mod tests {
 
     #[test]
     fn decode_pkcs7_with_timestamp() {
-        let decoded = base64::decode(
-            "MIIkWwYJKoZIhvcNAQcCoIIkTDCCJEgCAQExDzANBglghkgBZQMEAgEFADB5Bgor\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIkWwYJKoZIhvcNAQcCoIIkTDCCJEgCAQExDzANBglghkgBZQMEAgEFADB5Bgor\
                   BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG\
                   KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCD+xe8u4YoS6UEO\
                   jtW70wceL89huvuluOvdcbeefpOXLqCCDYEwggX/MIID56ADAgECAhMzAAABh3IX\
@@ -364,8 +368,8 @@ mod tests {
                   ou5BeU6YgdUYlkGnJ9xD3loc6+HvRz09U9XxSZmy0tctC3jNMv92wSFi2kKcmt7i\
                   9xzUxj4Ia+jA8G4zr6nZ1bKSIZ4PJ2AhgU0ZC6FFtrj5+7Q+xwaWiHHqyILB35/K\
                   k7qonnRYsNjUjEV6mMWyBU1uS4JTUWYJXNDXvi08PG0tf5gKtPAvt8NixqJE43w=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let pkcs7: Pkcs7Certificate = picky_asn1_der::from_bytes(&decoded).unwrap();
         let signer_info = pkcs7
@@ -387,8 +391,9 @@ mod tests {
 
     #[test]
     fn deserialize_problem_signature() {
-        let decoded = base64::decode(
-            "MIIjkgYJKoZIhvcNAQcCoIIjgzCCI38CAQExDzANBglghkgBZQMEAgEFADB5Bgor\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIjkgYJKoZIhvcNAQcCoIIjgzCCI38CAQExDzANBglghkgBZQMEAgEFADB5Bgor\
                         BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG\
                         KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCBOlmcSb72K+wH5\
                         7rgEoyM/xepQH0ZFeACdfeWgW6yh06CCDYEwggX/MIID56ADAgECAhMzAAABh3IX\
@@ -579,8 +584,8 @@ mod tests {
                         1VLKNa5p8Uwx4tsWz6RvIhztN/wvOo5yUoXR55DLKUMAp283TM4A3n6exf7iEb5N\
                         4jvlHkA6au1Uan+buR92YRqCvyUjqSzSJZo7w3NwLUM6GdFUIY0=\
                         ",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let pkcs7: Pkcs7Certificate = picky_asn1_der::from_bytes(&decoded).unwrap();
 

--- a/picky-asn1-x509/src/pkcs7/ctl.rs
+++ b/picky-asn1-x509/src/pkcs7/ctl.rs
@@ -231,20 +231,22 @@ pub struct PolicyQualifier {
 mod tests {
     use super::*;
     use crate::{AlgorithmIdentifier, ShaVariant};
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::date::UTCTime;
 
     #[test]
     fn decode_certificate_trust_list_entry() {
-        let ctl_entry_hex = base64::decode(
-            "MIIBKgQUzdTurmAArH9Aw4AsFx4wFIAwwHIxggEQMBgGCisGAQQBgjcKC34xCgQI\
+        let ctl_entry_hex = general_purpose::STANDARD
+            .decode(
+                "MIIBKgQUzdTurmAArH9Aw4AsFx4wFIAwwHIxggEQMBgGCisGAQQBgjcKC34xCgQI\
                                  AADZtUTB0gEwHgYKKwYBBAGCNwoLaTEQBA4wDAYKKwYBBAGCNzwDAjAgBgorBgEE\
                                  AYI3CgsdMRIEEPDEAvBATqmtvyWgPd8spvowJAYKKwYBBAGCNwoLFDEWBBQOrIJg\
                                  QFYnl+UlE/wq4QpTlVnkpDAwBgorBgEEAYI3CgtiMSIEIIhd5kw0Dj6nBljwHhFF\
                                  +Vf82ieqvuoaufqp/bAQLUB3MFoGCisGAQQBgjcKCwsxTARKTQBpAGMAcgBvAHMA\
                                  bwBmAHQAIABSAG8AbwB0ACAAQwBlAHIAdABpAGYAaQBjAGEAdABlACAAQQB1AHQA\
                                  aABvAHIAaQB0AHkAAAA=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let cert_fingerprint = OctetStringAsn1::from(ctl_entry_hex[6..26].to_vec());
 
@@ -317,8 +319,9 @@ mod tests {
 
     #[test]
     fn decode_certificate_trust_list() {
-        let ctl_hex = base64::decode(
-            "MIIBZzAMBgorBgEEAYI3CgMJAgkUAddM40UqdcsXDTIxMDUxOTE5MTUwM1owCQYF\
+        let ctl_hex = general_purpose::STANDARD
+            .decode(
+                "MIIBZzAMBgorBgEEAYI3CgMJAgkUAddM40UqdcsXDTIxMDUxOTE5MTUwM1owCQYF\
             Kw4DAhoFADCCATAwggEsBBQY98H8wwkCA/1bqi+GGnVJdsjdJTGCARIwGAYKKwYB\
             BAGCNwoLaDEKBAgAADYETd/TATAYBgorBgEEAYI3Cgt+MQoECAAAEMUektIBMBwG\
             CisGAQQBgjcKCwkxDgQMMAoGCCsGAQUFBwMIMCAGCisGAQQBgjcKCx0xEgQQT/fb\
@@ -326,8 +329,8 @@ mod tests {
             J+LwMDAGCisGAQQBgjcKC2IxIgQgW3iZh/PEBVuHAJQbM3g6Xxbgz/k36jIBH+BH\
             efdjUwgwRAYKKwYBBAGCNwoLCzE2BDRWAGUAcgBpAFMAaQBnAG4AIABUAGkAbQBl\
             ACAAUwB0AGEAbQBwAGkAbgBnACAAQwBBAAAA",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let cert_enhkey_usage_prop_id_entry = CTLEntryAttribute {
             oid: oids::cert_enhkey_usage_prop_id().into(),

--- a/picky-asn1-x509/src/pkcs7/signed_data.rs
+++ b/picky-asn1-x509/src/pkcs7/signed_data.rs
@@ -190,6 +190,7 @@ mod tests {
         oids, Certificate, EncapsulatedRsaPublicKey, Extension, Extensions, KeyIdentifier, Name, NameAttr, PublicKey,
         RsaPublicKey, SubjectPublicKeyInfo, TbsCertificate, Validity, Version,
     };
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::bit_string::BitString;
     use picky_asn1::date::UTCTime;
     use picky_asn1::restricted_string::{IA5String, PrintableString};
@@ -197,8 +198,9 @@ mod tests {
 
     #[test]
     fn decode_test() {
-        let pkcs7 = base64::decode(
-            "MIIGOgYJKoZIhvcNAQcCoIIGKzCCBicCAQExADALBgkqhkiG9w0BBwGgggYNMIIG\
+        let pkcs7 = general_purpose::STANDARD
+            .decode(
+                "MIIGOgYJKoZIhvcNAQcCoIIGKzCCBicCAQExADALBgkqhkiG9w0BBwGgggYNMIIG\
                 CTCCA/GgAwIBAgIUOnS/zC1zk2aJttmSVNtzX8rhMXwwDQYJKoZIhvcNAQELBQAw\
                 gZMxCzAJBgNVBAYTAlVBMRIwEAYDVQQIDAlIdW1ibGVHdXkxETAPBgNVBAcMCFNv\
                 bWVDaXR5MRkwFwYDVQQKDBBTb21lT3JnYW5pemF0aW9uMREwDwYDVQQLDAhTb21l\
@@ -232,8 +234,8 @@ mod tests {
                 t5vcoqFzuspOVIvdPLFY3pPZY9dxVNdDi4T6qJNZCq++Ukyc0LQOUkshF9HaHB3I\
                 xUDGjR5n4X0lkjgM5IvL+OaZREqWkD/tiCu4V/5Z86mZi6VwCcgYrp/Q4bFjsWBw\
                 p0mAUFZ9UjurAaEAMQA=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         assert_eq!(CmsVersion::V1, CmsVersion::from_u8(*pkcs7.get(25).unwrap()).unwrap());
 
@@ -322,8 +324,9 @@ mod tests {
 
     #[test]
     fn decode_with_crl() {
-        let decoded = base64::decode(
-            "MIIIxwYJKoZIhvcNAQcCoIIIuDCCCLQCAQExADALBgkqhkiG9w0BBwGgggXJMIIF\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIIxwYJKoZIhvcNAQcCoIIIuDCCCLQCAQExADALBgkqhkiG9w0BBwGgggXJMIIF\
                 xTCCA62gAwIBAgIUFYedpm34R9SrNONqEn43NrNlDHMwDQYJKoZIhvcNAQELBQAw\
                 cjELMAkGA1UEBhMCZmYxCzAJBgNVBAgMAmZmMQswCQYDVQQHDAJmZjELMAkGA1UE\
                 CgwCZmYxCzAJBgNVBAsMAmZmMQ8wDQYDVQQDDAZDQU5hbWUxHjAcBgkqhkiG9w0B\
@@ -370,8 +373,8 @@ mod tests {
                 LiFMcN1hzGQQo00ycuU6eF+Iz+H/olJyrpdJxf0jh2Sok71LX6YlALvfvZjW5eYc\
                 8AvDttigOLiDwm8eYAxsC8Ku4cMiMSkgs71vvmz0U/LHypZiNJsEEaR76NH9OLiz\
                 XCIYfP7WudYgfGBRRiw4WeB7jZNtVzFzkyiwliZLqocBuM8f1O2pv/QxAA==",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let mut issuer = Name::new();
         issuer.add_attr(NameAttr::CountryName, PrintableString::new("ff").unwrap());
@@ -408,8 +411,9 @@ mod tests {
 
     #[test]
     fn decode_certificate_trust_list_certificate_set() {
-        let decoded = base64::decode(
-            "\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "\
         oIINKTCCBhQwggP8oAMCAQICEzMAAABWo7N5AjhScwQAAAAAAFYwDQYJKoZIhvcN\
         AQELBQAwgYExCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYD\
         VQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKzAp\
@@ -481,8 +485,8 @@ mod tests {
         26lk147lM9KdQ4JLbjdmuQ1nV1RaSA7jivsf7QomvA000gpHhWEqI7HgVIpQFFaF\
         wP8t92mZRH0a9E18GA7hBwfuCWZSSnoaYqTli8+FooaKcZCxfdYR01Ee2lznzNYS\
         EHaork+TtWTJve3c+w==",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let certificate_set: CertificateSet = picky_asn1_der::from_bytes(&decoded).unwrap();
         check_serde!(certificate_set: CertificateSet in decoded);

--- a/picky-asn1-x509/src/pkcs7/signer_info.rs
+++ b/picky-asn1-x509/src/pkcs7/signer_info.rs
@@ -310,12 +310,14 @@ impl Serialize for UnsignedAttributeValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
 
     #[cfg(feature = "ctl")]
     #[test]
     fn decode_certificate_trust_list_signer_info() {
-        let decoded = base64::decode(
-            "MIICngIBATCBmTCBgTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIICngIBATCBmTCBgTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x\
             EDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlv\
             bjErMCkGA1UEAxMiTWljcm9zb2Z0IENlcnRpZmljYXRlIExpc3QgQ0EgMjAxMQIT\
             MwAAAFajs3kCOFJzBAAAAAAAVjANBglghkgBZQMEAgEFAKCB2jAYBgkqhkiG9w0B\
@@ -330,8 +332,8 @@ mod tests {
             cwcGic2ebDrpSZe0VVEgF9Blqk49W+JRwADVNdWFcDZbiAQv63vSy+VdFzKZer07\
             JAVDdVamvS5pk4MvNkszAG2KHsij6J3M97KcJY0FKuhPsfb9pnR61nmfDaFzoHOY\
             pkw=",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let signer_info: SignerInfo = picky_asn1_der::from_bytes(&decoded).unwrap();
         check_serde!(signer_info: SignerInfo in decoded);

--- a/picky-asn1-x509/src/pkcs7/timestamp.rs
+++ b/picky-asn1-x509/src/pkcs7/timestamp.rs
@@ -22,19 +22,21 @@ pub struct TimestampRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
 
     #[test]
     fn decode_timestamp_request() {
-        let decoded = base64::decode(
-            "MIIBIwYKKwYBBAGCNwMCATCCARMGCSqGSIb3DQEHAaCCAQQEggEAQrCUqwV+9+Fl\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "MIIBIwYKKwYBBAGCNwMCATCCARMGCSqGSIb3DQEHAaCCAQQEggEAQrCUqwV+9+Fl\
                   bgfJUwua28rmolLOZf/d3alzHUu6P1iV/9crZeu9ShrFdmQ4ZVWTpcR7bcVGPVsW\
                   QdUgx2n1mJCPied8YPjzC0wfJPvzZzOz9X919EAFRUi4VPs5qEsHJV57YP5mJ2UC\
                   XqXKSR9HhRO/06TSGz7hkFh+vpsKYVvIZpDXNJPRUilgEDQXjHCdMZyOzPb9wO8k\
                   cFHbUYZT9lVp9p8Wg+P56RdOANgtS5GKfku2BTsgbwxh5k8GzMnsiaf++O8LgMaE\
                   zsvEwbfbi+Egxi+7An0T7EttZcn6vbS28vtGKXOg6uzaiBN2u2KYq7f3KTq32sgD\
                   QgPEuhsAhQ==",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let timestamp_request: TimestampRequest = picky_asn1_der::from_bytes(&decoded).unwrap();
         check_serde!(timestamp_request: TimestampRequest in decoded);

--- a/picky-asn1-x509/src/private_key_info.rs
+++ b/picky-asn1-x509/src/private_key_info.rs
@@ -431,12 +431,14 @@ impl Drop for ECPrivateKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::bit_string::BitString;
 
     #[test]
     fn pkcs_8_private_key() {
-        let encoded = base64::decode(
-            "MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAq7BFUpkGp3+LQmlQ\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAq7BFUpkGp3+LQmlQ\
              Yx2eqzDV+xeG8kx/sQFV18S5JhzGeIJNA72wSeukEPojtqUyX2J0CciPBh7eqclQ\
              2zpAswIDAQABAkAgisq4+zRdrzkwH1ITV1vpytnkO/NiHcnePQiOW0VUybPyHoGM\
              /jf75C5xET7ZQpBe5kx5VHsPZj0CBb3b+wSRAiEA2mPWCBytosIU/ODRfq6EiV04\
@@ -444,8 +446,8 @@ mod tests {
              5QIhAKthiYcYKlL9h8bjDsQhZDUACPasjzdsDEdq8inDyLOFAiEAmCr/tZwA3qeA\
              ZoBzI10DGPIuoKXBd3nk/eBxPkaxlEECIQCNymjsoI7GldtujVnr1qT+3yedLfHK\
              srDVjIT3LsvTqw==",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         let modulus = IntegerAsn1::from(encoded[35..100].to_vec());
         let public_exponent = IntegerAsn1::from(encoded[102..105].to_vec());
@@ -474,8 +476,9 @@ mod tests {
         // https://github.com/Devolutions/picky-rs/issues/53
         // We want to support these for now.
 
-        let encoded = base64::decode(
-            "MIIDMAIBADANBgkqhkiG9w0BAQEFAASCAxowggMWAgEAAoIBAOB9jOJvCkMHOc98Q\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIIDMAIBADANBgkqhkiG9w0BAQEFAASCAxowggMWAgEAAoIBAOB9jOJvCkMHOc98Q\
              GPFikxAvBKANkme5f/nNuNnEnbefoKDFkS6ElfqASAAkIHxUREnRvBTTa6b+qba/0\
              DhBuXsYGCl8VF0pUE4JGujv1HIi5aRCar0WmY66s7DJ4uR3Nk9Jy0WeRiH4yyzEIG\
              8+6QDu4d/U6slWTmE8eZtQEE7rz4FGpQU9OhrGM3xJOIIbLX/xU2SFt83Xs3JREEt\
@@ -492,23 +495,24 @@ mod tests {
              yOdodNnpUCgYDwEo/sPJNaPOzc7fpaQr2PUUJ3ksL0ncGRO2h1JGYgDtWe5u1srSI\
              DlpM2NdYSZyT04ebOF2SqNUBwY3LB1tPOFnjYwCutp4c75OYhOor7TodZHlzt3GeQ\
              ntUw6XbHX0ohTgs4u2NXwOTq5yKeW4VYzuevN5ksF8GoW2noalpn+w==",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         picky_asn1_der::from_bytes::<PrivateKeyInfo>(&encoded).unwrap();
     }
 
     #[test]
     fn decode_ec_key() {
-        let decoded = base64::decode(
-            "\
+        let decoded = general_purpose::STANDARD
+            .decode(
+                "\
         MIHcAgEBBEIBhqphIGu2PmlcEb6xADhhSCpgPUulB0s4L2qOgolRgaBx4fNgINFE\
         mBsSyHJncsWG8WFEuUzAYy/YKz2lP0Qx6Z2gBwYFK4EEACOhgYkDgYYABABwBevJ\
         w/+Xh6I98ruzoTX3MNTsbgnc+glenJRCbEJkjbJrObFhbfgqP52r1lAy2RxuShGi\
         NYJJzNPT6vR1abS32QFtvTH7YbYa6OWk9dtGNY/cYxgx1nQyhUuofdW7qbbfu/Ww\
         TP2oFsPXRAavZCh4AbWUn8bAHmzNRyuJonQBKlQlVQ==",
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let ec_key = ECPrivateKey {
             version: IntegerAsn1([1].into()),
@@ -524,7 +528,7 @@ mod tests {
 
     #[test]
     fn decode_pkcs8_ec_key() {
-        let decoded = base64::decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgKZqrmOg/cDZ4tPCn\
+        let decoded = general_purpose::STANDARD.decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgKZqrmOg/cDZ4tPCn\
                                                             4LROs145nxx+ssufvflL8cROxFmhRANCAARmU90fCSTsncefY7hVeKw1WIg/YQmT\
                                                             4DGJ7nJPZ+WXAd/xxp4c0bHGlIOju/U95ITPN9dAmro7OUTDJpz+rzGW").unwrap();
         let expected_pkcs8_ec_key = PrivateKeyInfo {

--- a/picky-asn1-x509/src/subject_public_key_info.rs
+++ b/picky-asn1-x509/src/subject_public_key_info.rs
@@ -119,20 +119,22 @@ impl<'de> de::Deserialize<'de> for SubjectPublicKeyInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
     use num_bigint_dig::BigInt;
 
     #[test]
     fn rsa_subject_public_key_info() {
-        let encoded = base64::decode(
-            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiLoIx\
+        let encoded = general_purpose::STANDARD
+            .decode(
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiLoIx\
              mXaZAFRBKtHYZhiF8m+pYR+xGIpupvsdDEvKO92D6fIccgVLIW6p6sSNk\
              oXx5J6KDSMbA/chy5M6pRvJkaCXCI4zlCPMYvPhI8OxN3RYPfdQTLpgPy\
              wrlfdn2CAum7o4D8nR4NJacB3NfPnS9tsJ2L3p5iHviuTB4xm03IKmPPq\
              saJy+nXUFC1XS9E/PseVHRuNvKa7WmlwSZngQzKAVSIwqpgCc+oP1pKEe\
              J0M3LHFo8ao5SuzhfXUIGrPnkUKEE3m7B0b8xXZfP1N6ELoonWDK+RMgY\
              IBaZdgBhPfHxF8KfTHvSzcUzWZojuR+ynaFL9AJK+8RiXnB4CJwIDAQAB",
-        )
-        .expect("invalid base64");
+            )
+            .expect("invalid base64");
 
         // RSA algorithm identifier
 

--- a/picky-asn1-x509/src/version.rs
+++ b/picky-asn1-x509/src/version.rs
@@ -71,6 +71,7 @@ impl<'de> Deserialize<'de> for Version {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1::wrapper::{ExplicitContextTag9, Optional};
     use picky_asn1_der::Asn1DerError;
 

--- a/picky-signtool/Cargo.toml
+++ b/picky-signtool/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.69"
 clap = "2.34.0"
 walkdir = "2.3.2"
-base64 = "0.13.1"
+base64 = "0.21.0"
 encoding_rs = "0.8.32"
 lief-cwal = "0.1.0"
 picky = { version = "7.0.0-rc.3", default-features = false, features = ["wincert", "ctl", "ctl_http_fetch", "http_timestamp"] }

--- a/picky-signtool/src/verify.rs
+++ b/picky-signtool/src/verify.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context};
+use base64::{engine::general_purpose, Engine as _};
 use clap::ArgMatches;
 use lief::Binary;
 
@@ -170,7 +171,9 @@ pub fn authenticode_signature_ps_from_file(file_path: &Path) -> anyhow::Result<A
     let signature = extract_ps_authenticode_signature(buffer.as_ref())
         .with_context(|| format!("Failed to extract Authenticode signature from {:?}", file_path))?;
 
-    let der_signature = base64::decode(signature).context("Failed to convert signature to DER")?;
+    let der_signature = general_purpose::STANDARD
+        .decode(signature)
+        .context("Failed to convert signature to DER")?;
 
     let authenticode_signature = AuthenticodeSignature::from_der(&der_signature)
         .with_context(|| format!("Failed to deserialize Authenticode signature for {:?}", file_path))?;

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -26,7 +26,7 @@ picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.9", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
 serde = { version = "1.0.152", features = ["derive"] }
 oid = { version = "0.2.1", features = ["serde_support"] }
-base64 = "0.13.1"
+base64 = "0.21.0"
 thiserror = "1.0.38"
 byteorder = { version = "1.4.3", optional = true }
 chrono = { version = "0.4.23", optional = true }

--- a/picky/src/http/http_signature.rs
+++ b/picky/src/http/http_signature.rs
@@ -2,7 +2,7 @@ use crate::hash::HashAlgorithm;
 use crate::http::http_request::{HttpRequest, HttpRequestError};
 use crate::key::{PrivateKey, PublicKey};
 use crate::signature::{SignatureAlgorithm, SignatureError};
-use base64::{DecodeError, URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose, DecodeError, Engine as _};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -633,9 +633,9 @@ impl<'a> HttpSignatureBuilder<'a> {
             created,
             expires,
             signature: if legacy {
-                base64::encode_config(&signature_binary, URL_SAFE_NO_PAD)
+                general_purpose::URL_SAFE_NO_PAD.encode(&signature_binary)
             } else {
-                base64::encode(&signature_binary)
+                general_purpose::STANDARD.encode(&signature_binary)
             },
             algorithm: Some(HttpSigAlgorithm::Known(signature_type)),
             legacy,
@@ -802,9 +802,9 @@ impl<'a> HttpSignatureVerifier<'a> {
         };
 
         let decoded_signature = if self.http_signature.legacy {
-            base64::decode_config(&self.http_signature.signature, URL_SAFE_NO_PAD)?
+            general_purpose::URL_SAFE_NO_PAD.decode(&self.http_signature.signature)?
         } else {
-            base64::decode(&self.http_signature.signature)?
+            general_purpose::STANDARD.decode(&self.http_signature.signature)?
         };
 
         signature_type.verify(public_key, signing_string.as_bytes(), &decoded_signature)?;

--- a/picky/src/key/mod.rs
+++ b/picky/src/key/mod.rs
@@ -526,7 +526,7 @@ mod tests {
         PublicKey::from_pem(&RSA_PUBLIC_KEY_PEM.parse::<Pem>().expect("pem")).expect("public key");
     }
 
-    const GARBAGE_PEM: &str = "-----BEGIN GARBAGE-----GARBAGE-----END GARBAGE-----";
+    const GARBAGE_PEM: &str = "-----BEGIN GARBAGE-----R0FSQkFHRQo=-----END GARBAGE-----";
 
     #[test]
     fn public_key_from_garbage_pem_err() {

--- a/picky/src/ssh/decode.rs
+++ b/picky/src/ssh/decode.rs
@@ -8,6 +8,7 @@ use crate::ssh::certificate::{
 use crate::ssh::private_key::{KdfOption, SshBasePrivateKey, SshPrivateKeyError};
 use crate::ssh::public_key::{SshBasePublicKey, SshPublicKey, SshPublicKeyError};
 use crate::ssh::{read_to_buffer_until_whitespace, Base64Reader, SSH_RSA_KEY_TYPE};
+use base64::engine::general_purpose;
 use byteorder::{BigEndian, ReadBytesExt};
 use num_bigint_dig::BigUint;
 use std::io::{self, Cursor, Read};
@@ -201,7 +202,7 @@ impl SshComplexTypeDecode for SshPublicKey {
             SSH_RSA_KEY_TYPE => {
                 read_to_buffer_until_whitespace(&mut stream, &mut buffer)?;
                 let mut slice = buffer.as_slice();
-                let decoder = Base64Reader::new(&mut slice, base64::STANDARD);
+                let decoder = Base64Reader::new(&mut slice, &general_purpose::STANDARD);
                 SshComplexTypeDecode::decode(decoder)?
             }
             _ => return Err(SshPublicKeyError::UnknownKeyType),
@@ -254,7 +255,7 @@ impl SshComplexTypeDecode for SshCertificate {
         read_to_buffer_until_whitespace(&mut stream, &mut cert_data)?;
 
         let mut cert_data = cert_data.as_slice();
-        let mut cert_data = Base64Reader::new(&mut cert_data, base64::STANDARD);
+        let mut cert_data = Base64Reader::new(&mut cert_data, &general_purpose::STANDARD);
 
         let cert_key_type = cert_data.read_ssh_string()?;
         let cert_key_type = SshCertKeyType::try_from(cert_key_type)?;

--- a/picky/src/ssh/encode.rs
+++ b/picky/src/ssh/encode.rs
@@ -9,6 +9,7 @@ use crate::ssh::private_key::{
 use crate::ssh::public_key::{SshBasePublicKey, SshPublicKey, SshPublicKeyError};
 use crate::ssh::{Base64Writer, SSH_RSA_KEY_TYPE};
 use aes::cipher::{KeyIvInit, StreamCipher};
+use base64::engine::general_purpose;
 use byteorder::{BigEndian, WriteBytesExt};
 use num_bigint_dig::{BigUint, ModInverse};
 use rsa::{PublicKeyParts, RsaPrivateKey, RsaPublicKey};
@@ -183,7 +184,7 @@ impl SshComplexTypeEncode for SshPublicKey {
         };
 
         {
-            let mut base64_write = Base64Writer::new(&mut stream, base64::STANDARD);
+            let mut base64_write = Base64Writer::new(&mut stream, &general_purpose::STANDARD);
             self.inner_key.encode(&mut base64_write)?;
             base64_write.finish()?;
         }
@@ -299,7 +300,7 @@ impl SshComplexTypeEncode for SshCertificate {
         stream.write_all(self.cert_key_type.as_str().as_bytes())?;
         stream.write_u8(b' ')?;
 
-        let mut cert_data = Base64Writer::new(stream, base64::STANDARD);
+        let mut cert_data = Base64Writer::new(stream, &general_purpose::STANDARD);
 
         cert_data.write_ssh_string(self.cert_key_type.as_str())?;
         cert_data.write_ssh_bytes(&self.nonce)?;

--- a/picky/src/ssh/mod.rs
+++ b/picky/src/ssh/mod.rs
@@ -8,13 +8,11 @@ pub use certificate::{SshCertKeyType, SshCertType, SshCertificate, SshCertificat
 pub use private_key::SshPrivateKey;
 pub use public_key::SshPublicKey;
 
-use base64::read::DecoderReader;
-use base64::write::EncoderWriter;
 use byteorder::ReadBytesExt;
 use std::io::{self, Read};
 
-pub type Base64Writer<T> = EncoderWriter<T>;
-pub type Base64Reader<'a, R> = DecoderReader<'a, R>;
+pub(crate) type Base64Writer<'a, T, E> = base64::write::EncoderWriter<'a, T, E>;
+pub(crate) type Base64Reader<'a, T, E> = base64::read::DecoderReader<'a, T, E>;
 
 const SSH_RSA_KEY_TYPE: &str = "ssh-rsa";
 

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -1295,6 +1295,7 @@ mod test {
     use crate::pem::parse_pem;
     use crate::x509::certificate::{CertType, CertificateBuilder};
     use crate::x509::{Csr, KeyIdGenMethod};
+    use base64::{engine::general_purpose, Engine as _};
     use picky_asn1_x509::Extension;
 
     const RSA_PRIVATE_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----\n\
@@ -2422,7 +2423,7 @@ mod test {
                             2/zdX1wrovKdyKa8bF+34x+bnObgiiiNs0vqWXELgiCu2pHtcEHnHv70H62f3jBUKc5gIZ\
                             PHvJPJq54bXy2JxFBRUZFo8r8af75X3+atMp9eSErcSUK2UTygICS2lz/ZRaIZ";
 
-        let der_signature = base64::decode(signature).unwrap();
+        let der_signature = general_purpose::STANDARD.decode(signature).unwrap();
         let authenticode_signature = AuthenticodeSignature::from_der(&der_signature).unwrap();
 
         let time = UtcDate::new(2022, 7, 9, 7, 48, 3).unwrap();
@@ -2529,7 +2530,7 @@ mod test {
                               CmE1KKJ1vU1qzC03SsoPtxHKFKo5cJ88tiehDxCKDNjf1c2JJy9iGEaQZN9tLCPHtz/W6p\
                               Q355Y6GW1xdqI879CvAQX/Dy9+g42WddYjeJE0iD";
 
-        let der_signature = base64::decode(signature).unwrap();
+        let der_signature = general_purpose::STANDARD.decode(signature).unwrap();
         let authenticode_signature = AuthenticodeSignature::from_der(&der_signature).unwrap();
 
         let time = UtcDate::new(2022, 7, 9, 7, 48, 3).unwrap();


### PR DESCRIPTION
* Modifiy the code to adjust the incompatible API changes
* Replace the `GARBAGE` string in pem tests with the corresponding base64 encoded string `R0FSQkFHRQo=`

Fixes #215 