### PR TITLE
chore: include license files in published crates

### DIFF
--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -14,7 +14,7 @@ description = "An ASN.1-DER subset for serde"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 readme = "README.md"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
 picky-asn1 = { version = "0.7", path = "../picky-asn1" }

--- a/picky-asn1-der/LICENSE-APACHE
+++ b/picky-asn1-der/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1-der/LICENSE-MIT
+++ b/picky-asn1-der/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-asn1-x509/LICENSE-APACHE
+++ b/picky-asn1-x509/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1-x509/LICENSE-MIT
+++ b/picky-asn1-x509/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-asn1/LICENSE-APACHE
+++ b/picky-asn1/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1/LICENSE-MIT
+++ b/picky-asn1/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -10,7 +10,7 @@ description = "Encode/decode Kerberos ASN.1 DER structs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 readme = "README.md"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
 picky-asn1 = { version = "0.7", path = "../picky-asn1" }

--- a/picky-krb/LICENSE-APACHE
+++ b/picky-krb/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-krb/LICENSE-MIT
+++ b/picky-krb/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.65"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
 picky-asn1 = { version = "0.7", path = "../picky-asn1", features = ["zeroize"] }

--- a/picky/LICENSE-APACHE
+++ b/picky/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky/LICENSE-MIT
+++ b/picky/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
I've added symbolic links to the license files to all workspace members that don't have `package.publish = false` set in their Cargo.toml file, and adapted `package.include` settings to include these files where necessary. I've tested the change locally, and `cargo package` included the license texts in `.crate` tarballs as intended.

Fixes #230
