### PR TITLE
fix(ffi): Fix netcore packaging on macOS targets

### DIFF
--- a/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
+++ b/ffi/dotnet/Devolutions.Picky/Devolutions.Picky.targets
@@ -4,7 +4,6 @@
     <IsPowerShell Condition="$(DefineConstants.Contains('__POWERSHELL__'))">true</IsPowerShell>
     <IsAndroid Condition="$(TargetFramework.ToUpper().Contains('ANDROID'))">true</IsAndroid>
     <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">true</IsIOS>
-    <IsNet6Mac Condition="$(TargetFramework.Contains('-macos'))">true</IsNet6Mac>
   </PropertyGroup>
   <ItemGroup>
   
@@ -64,7 +63,7 @@
   </ItemGroup>
 
   <!-- Xamarin.Mac -->
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND '$(IsNet6Mac)' != 'true'">
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND !$(TargetFramework.Contains('net'))">
     <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsPicky.dylib">
       <Kind>Dynamic</Kind>
       <SmartLink>False</SmartLink>


### PR DESCRIPTION
Don't use `NativeReference` in the targets file on macOS when targeting dotnet