### PR TITLE
chore: update rust toolchain version

### DIFF
--- a/ffi/src/pkcs12.rs
+++ b/ffi/src/pkcs12.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)] // We have wrapped the `Arc<Mutex<...>>` in a `Box`, as required by the `diplomat` crate.
 use crate::error::ffi::PickyError;
 
 #[diplomat::bridge]

--- a/picky-asn1-der/src/ser/mod.rs
+++ b/picky-asn1-der/src/ser/mod.rs
@@ -270,7 +270,7 @@ impl<'a, 'se> serde::ser::Serializer for &'a mut Serializer<'se> {
         Err(Asn1DerError::UnsupportedType)
     }
 
-    fn serialize_newtype_struct<T: ?Sized + Serialize>(mut self, name: &'static str, value: &T) -> Result<Self::Ok> {
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(self, name: &'static str, value: &T) -> Result<Self::Ok> {
         debug_log!("serialize_newtype_struct: {}", name);
 
         match name {

--- a/picky-krb/src/crypto/aes/aes128_cts_hmac_sha1_96.rs
+++ b/picky-krb/src/crypto/aes/aes128_cts_hmac_sha1_96.rs
@@ -36,7 +36,7 @@ impl Cipher for Aes128CtsHmacSha196 {
             key_usage,
             payload,
             &AesSize::Aes128,
-            OsRng::default().gen::<[u8; AES_BLOCK_SIZE]>(),
+            OsRng.gen::<[u8; AES_BLOCK_SIZE]>(),
         )
     }
 

--- a/picky-krb/src/crypto/aes/aes256_cts_hmac_sha1_96.rs
+++ b/picky-krb/src/crypto/aes/aes256_cts_hmac_sha1_96.rs
@@ -32,7 +32,7 @@ impl Cipher for Aes256CtsHmacSha196 {
             key_usage,
             payload,
             &AesSize::Aes256,
-            OsRng::default().gen::<[u8; AES_BLOCK_SIZE]>(),
+            OsRng.gen::<[u8; AES_BLOCK_SIZE]>(),
         )
     }
 

--- a/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
+++ b/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
@@ -35,7 +35,7 @@ impl Cipher for Des3CbcSha1Kd {
     }
 
     fn encrypt(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
-        encrypt_message(key, key_usage, payload, OsRng::default().gen::<[u8; DES3_BLOCK_SIZE]>())
+        encrypt_message(key, key_usage, payload, OsRng.gen::<[u8; DES3_BLOCK_SIZE]>())
     }
 
     fn decrypt(&self, key: &[u8], key_usage: i32, cipher_data: &[u8]) -> KerberosCryptoResult<Vec<u8>> {

--- a/picky-krb/src/negoex/mod.rs
+++ b/picky-krb/src/negoex/mod.rs
@@ -94,7 +94,7 @@ impl<T: NegoexDataType<Error = io::Error>> NegoexDataType for Vec<T> {
     fn size(&self) -> usize {
         4 /* offset */ +
         4 /* count */ +
-        self.get(0).map(|e| e.size()).unwrap_or_default() * self.len()
+        self.first().map(|e| e.size()).unwrap_or_default() * self.len()
     }
 
     fn decode(mut from: impl Read, message: &[u8]) -> Result<Self, Self::Error> {

--- a/picky/src/jose/jwe.rs
+++ b/picky/src/jose/jwe.rs
@@ -940,11 +940,9 @@ fn prepare_ecdh_decryption_key(
 
             wrapping_alg.decrypt_key(header.enc, encrypted_key, &shared_secret)
         }
-        _ => {
-            Err(JweError::UnsupportedAlgorithm {
-                algorithm: format!("Algorithm `{}` is not supported for EC & ED keys", header.alg.name()),
-            })
-        }
+        _ => Err(JweError::UnsupportedAlgorithm {
+            algorithm: format!("Algorithm `{}` is not supported for EC & ED keys", header.alg.name()),
+        }),
     }
 }
 

--- a/picky/src/jose/jwe.rs
+++ b/picky/src/jose/jwe.rs
@@ -941,9 +941,9 @@ fn prepare_ecdh_decryption_key(
             wrapping_alg.decrypt_key(header.enc, encrypted_key, &shared_secret)
         }
         _ => {
-            return Err(JweError::UnsupportedAlgorithm {
+            Err(JweError::UnsupportedAlgorithm {
                 algorithm: format!("Algorithm `{}` is not supported for EC & ED keys", header.alg.name()),
-            });
+            })
         }
     }
 }

--- a/picky/src/key/mod.rs
+++ b/picky/src/key/mod.rs
@@ -874,7 +874,9 @@ impl PublicKey {
 
     pub fn to_pkcs1(&self) -> Result<Vec<u8>, KeyError> {
         let picky_asn1_x509::PublicKey::Rsa(BitStringAsn1Container(rsa_public_key)) = &self.0.subject_public_key else {
-            return Err(KeyError::Rsa { context: String::from("can’t export a non-RSA key to PKCS#1 format") });
+            return Err(KeyError::Rsa {
+                context: String::from("can’t export a non-RSA key to PKCS#1 format"),
+            });
         };
 
         picky_asn1_der::to_vec(rsa_public_key).map_err(|e| KeyError::Asn1Serialization {

--- a/picky/src/pkcs12/encryption.rs
+++ b/picky/src/pkcs12/encryption.rs
@@ -640,9 +640,9 @@ mod tests {
     #[test]
     fn pbes1_3des_roundtrip() {
         let password = b"\0a\0b\0c\0\0";
-        let salt = (0..8).into_iter().collect::<Vec<u8>>();
+        let salt = (0..8).collect::<Vec<u8>>();
         let iterations = 2000;
-        let data = (0..123).into_iter().collect::<Vec<u8>>();
+        let data = (0..123).collect::<Vec<u8>>();
         let encrypted = encrypt_pbes1(Pbes1Cipher::ShaAnd3Key3DesCbc, password, &salt, iterations, &data).unwrap();
         let decrypted = decrypt_pbes1(Pbes1Cipher::ShaAnd3Key3DesCbc, password, &salt, iterations, &encrypted).unwrap();
         assert_eq!(decrypted, data);
@@ -651,9 +651,9 @@ mod tests {
     #[test]
     fn pbes1_rc2_roundtrip() {
         let password = b"\0b\0c\0a\0\0";
-        let salt = (0..8).into_iter().collect::<Vec<u8>>();
+        let salt = (0..8).collect::<Vec<u8>>();
         let iterations = 2048;
-        let data = (0..124).into_iter().collect::<Vec<u8>>();
+        let data = (0..124).collect::<Vec<u8>>();
         let encrypted = encrypt_pbes1(Pbes1Cipher::ShaAnd40BitRc2Cbc, password, &salt, iterations, &data).unwrap();
         let decrypted = decrypt_pbes1(Pbes1Cipher::ShaAnd40BitRc2Cbc, password, &salt, iterations, &encrypted).unwrap();
         assert_eq!(decrypted, data);
@@ -665,17 +665,17 @@ mod tests {
     #[case(Pbes2AesCbcEncryptionAsn1::Aes256)]
     fn pbes2_aes256_roundtrip(#[case] aes: Pbes2AesCbcEncryptionAsn1) {
         let password = b"test";
-        let data = (0..123).into_iter().collect::<Vec<u8>>();
+        let data = (0..123).collect::<Vec<u8>>();
         let params = Pbes2ParamsAsn1 {
             key_derivation_func: Pbes2KeyDerivationFuncAsn1::Pbkdf2(Pbkdf2ParamsAsn1 {
-                salt: Pbkdf2SaltSourceAsn1::Specified(OctetStringAsn1((0..8).into_iter().collect())),
+                salt: Pbkdf2SaltSourceAsn1::Specified(OctetStringAsn1((0..8).collect())),
                 iteration_count: 2000,
                 key_length: None,
                 prf: Some(Pbkdf2PrfAsn1::HmacWithSha256),
             }),
             encryption_scheme: Pbes2EncryptionSchemeAsn1::AesCbc {
                 kind: aes,
-                iv: OctetStringAsn1((0..16).into_iter().collect()),
+                iv: OctetStringAsn1((0..16).collect()),
             },
         };
         let encrypted = encrypt_pbes2(&params, password, &data).unwrap();

--- a/picky/src/pkcs12/safe_bag.rs
+++ b/picky/src/pkcs12/safe_bag.rs
@@ -322,7 +322,7 @@ impl SecretSafeBag {
     }
 }
 
-fn attributes_to_asn1(attributes: &Vec<Pkcs12Attribute>) -> Option<Vec<Pkcs12AttributeAsn1>> {
+fn attributes_to_asn1(attributes: &[Pkcs12Attribute]) -> Option<Vec<Pkcs12AttributeAsn1>> {
     if attributes.is_empty() {
         None
     } else {

--- a/picky/src/x509/pkcs7/authenticode.rs
+++ b/picky/src/x509/pkcs7/authenticode.rs
@@ -172,7 +172,7 @@ impl AuthenticodeSignature {
 
         let certificates = pkcs7.decode_certificates();
 
-        let signing_cert = certificates.get(0).ok_or(AuthenticodeError::NoCertificates)?;
+        let signing_cert = certificates.first().ok_or(AuthenticodeError::NoCertificates)?;
 
         let issuer_and_serial_number = IssuerAndSerialNumber {
             issuer: signing_cert.issuer_name().into(),
@@ -786,7 +786,7 @@ impl<'a> AuthenticodeValidator<'a> {
                                         && !kp_lifetime_signing_is_present
                                     {
                                         // check if certificates in the timestamp have the right chain
-                                        if let Some(leaf) = certificates.get(0) {
+                                        if let Some(leaf) = certificates.first() {
                                             let timestamp_chain_validator = leaf.verifier();
                                             let timestamp_chain = certificates
                                                 .iter()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.76.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.70.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
update Rust toolchain versoin to 1.70.0, as it is the minimum version needed to run `just diplomat-install` in ffi crate.

Fixed new clippy waring