### PR TITLE
build(wasm): use vite to embed the WASM module in base64

### DIFF
--- a/ffi/wasm/README.md
+++ b/ffi/wasm/README.md
@@ -11,15 +11,14 @@ This should be run in the CI.
 2. Build the package: 
 
     ```
-    $ wasm-pack build --target web --scope devolutions --out-name picky
+    $ npm run build:wasm 
+    $ npm run build
     ```
 
-3. Rename `@devolutions/picky-wasm` to `@devolutions/picky` in `pkg/package.json`.
-
-4. Publish to npm:
+3. Publish to npm:
 
     ```
-    $ wasm-pack publish
+    $ npm publish
     ```
 
 ## Testing

--- a/ffi/wasm/main.ts
+++ b/ffi/wasm/main.ts
@@ -1,2 +1,3 @@
 export * from './pkg/picky.js';
-export { default as init } from './pkg/picky.js';
+import init from './pkg/picky.js';
+export default init;

--- a/ffi/wasm/main.ts
+++ b/ffi/wasm/main.ts
@@ -1,0 +1,2 @@
+export * from './pkg/picky.js';
+export { default as init } from './pkg/picky.js';

--- a/ffi/wasm/package.json
+++ b/ffi/wasm/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@devolutions/picky",
+  "collaborators": [
+    "Benoît CORTIER <bcortier@proton.me>"
+  ],
+  "description": "Portable X.509, PKI, JOSE and HTTP signature implementation.",
+  "version": "0.10.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Devolutions/picky-rs"
+  },
+  "main": "./dist/picky.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "build:wasm": "wasm-pack build --target web --scope devolutions --out-name picky --out-dir ./pkg --release",
+    "clean": "npm run clean:win && npm run clean:lin",
+    "clean:win": "node -e \"if (process.platform === 'win32') process.exit(1)\" || (if exist dist rmdir /Q /S dist && if exist pkg rmdir /Q /S pkg)",
+    "clean:lin": "node -e \"if (process.platform !== 'win32') process.exit(1)\" || (rm -rf dist pkg)"
+  },
+  "author": "",
+  "license": "MIT OR Apache-2.0",
+  "types": "./dist/main.d.ts",
+  "type": "module",
+  "dependencies": {
+    "vite": "^4.2.12",
+    "vite-plugin-dts": "^3.9.1",
+    "vite-plugin-top-level-await": "^1.3.1",
+    "vite-plugin-wasm": "^3.2.2"
+  }
+}

--- a/ffi/wasm/publish.ps1
+++ b/ffi/wasm/publish.ps1
@@ -2,14 +2,14 @@
 
 $ErrorActionPreference = "Stop"
 
-wasm-pack build --target bundler --scope devolutions --out-name picky
+npm run build:wasm && npm run build
 
 if ($LastExitCode -ne 0)
 {
     throw "wasm-pack build failed"
 }
 
-wasm-pack publish --access=public
+npm run publish 
 
 if ($LastExitCode -ne 0)
 {

--- a/ffi/wasm/vite.config.ts
+++ b/ffi/wasm/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import topLevelAwait from 'vite-plugin-top-level-await';
+import dtsPlugin from 'vite-plugin-dts';
+import wasm from 'vite-plugin-wasm';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'main.ts',
+      name: '@Devolutions/picky',
+      formats: ['es'],
+    },
+  },
+  assetsInclude: ['pkg/picky_bg.wasm'],
+  plugins: [wasm(), topLevelAwait(), dtsPlugin()],
+});


### PR DESCRIPTION
Use Vite to rebuild Picky WASM into Base64 encoded JavaScript. This approach have the following benefits for angular 18:
1. Import and use, no extra configuration
    In Angular 18, if we want to use WASM, we need to configure Vite (that is used bu Angular 18) to use [vite-plugin-wasm](https://www.npmjs.com/package/vite-plugin-wasm).
2. Zero interface change
3. Backward compatibility
    As it is just JavaScript file, any project can just import it without worrying about how to load WASM