### PR TITLE
build(wasm): clean up npm package

### DIFF
--- a/ffi/wasm/.gitignore
+++ b/ffi/wasm/.gitignore
@@ -1,5 +1,6 @@
 bin/
 pkg/
+dist/
 node_modules/
 wasm-pack.log
 package-lock.json

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "0.11.0"
+version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "0.11.0"
+version = "0.0.0"
 authors = ["Benoît CORTIER <bcortier@proton.me>"]
 edition = "2021"
 publish = false

--- a/ffi/wasm/README.md
+++ b/ffi/wasm/README.md
@@ -11,7 +11,6 @@ This should be run in the CI.
 2. Build the package: 
 
     ```
-    $ npm run build:wasm 
     $ npm run build
     ```
 

--- a/ffi/wasm/main.ts
+++ b/ffi/wasm/main.ts
@@ -1,3 +1,6 @@
-export * from './pkg/picky.js';
-import init from './pkg/picky.js';
-export default init;
+// Re-export all exports.
+export * from "./pkg/picky";
+
+// Re-export the default export as default as well.
+import { default as _wasm_init } from "./pkg/picky";
+export default _wasm_init;

--- a/ffi/wasm/package.json
+++ b/ffi/wasm/package.json
@@ -1,33 +1,42 @@
 {
   "name": "@devolutions/picky",
+  "version": "0.12.0",
+  "author": "Benoît CORTIER",
+  "email": "bcortier@devolutions.net",
   "collaborators": [
-    "Benoît CORTIER <bcortier@proton.me>"
+    "Vladyslav NIKONOV",
+    "Irving OU"
   ],
   "description": "Portable X.509, PKI, JOSE and HTTP signature implementation.",
-  "version": "0.10.1",
+  "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Devolutions/picky-rs"
   },
-  "main": "./dist/picky.js",
+  "scripts": {
+    "build": "npm run build:wasm && npm run build:vite",
+    "build:wasm": "wasm-pack build --target web --scope devolutions --out-name picky --out-dir ./pkg --release",
+    "build:vite": "vite build && node rewrite-location.js",
+    "clean": "rimraf dist && rimraf pkg"
+  },
+  "type": "module",
   "files": [
     "dist"
   ],
-  "scripts": {
-    "build": "vite build",
-    "build:wasm": "wasm-pack build --target web --scope devolutions --out-name picky --out-dir ./pkg --release",
-    "clean": "npm run clean:win && npm run clean:lin",
-    "clean:win": "node -e \"if (process.platform === 'win32') process.exit(1)\" || (if exist dist rmdir /Q /S dist && if exist pkg rmdir /Q /S pkg)",
-    "clean:lin": "node -e \"if (process.platform !== 'win32') process.exit(1)\" || (rm -rf dist pkg)"
+  "main": "./dist/picky.umd.cjs",
+  "module": "./dist/picky.js",
+  "types": "./dist/picky.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/picky.umd.cjs",
+      "import": "./dist/picky.js"
+    }
   },
-  "author": "",
-  "license": "MIT OR Apache-2.0",
-  "types": "./dist/main.d.ts",
-  "type": "module",
-  "dependencies": {
-    "vite": "^4.2.12",
-    "vite-plugin-dts": "^3.9.1",
-    "vite-plugin-top-level-await": "^1.3.1",
-    "vite-plugin-wasm": "^3.2.2"
+  "devDependencies": {
+    "rimraf": "^5.0.7",
+    "vite": "^5.3.2",
+    "vite-plugin-static-copy": "^1.0.6",
+    "vite-plugin-top-level-await": "^1.4.1",
+    "vite-plugin-wasm": "^3.3.0"
   }
 }

--- a/ffi/wasm/rewrite-location.js
+++ b/ffi/wasm/rewrite-location.js
@@ -1,0 +1,33 @@
+/***********
+This is a workaround for this issue: https://github.com/vitejs/vite/issues/8427
+Actually, I’m not even sure we are really working around the exact same issue.
+Indeed, this dance is only required when bundling using vite 5, but wasn’t required when using vite 4.
+***********/
+
+import { readFile, writeFile } from "fs";
+import path from "path";
+import { fileURLToPath } from 'url';
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+const preBundledPickyJs = path.join(rootDir, './dist/picky.js');
+
+readFile(preBundledPickyJs, 'utf8', (err, data) => {
+    if (err) {
+        console.error('Error reading the file:', err);
+        return;
+    }
+
+    // Replace all instances of 'import.meta.url' with 'self.location'.
+    const modifiedData = data.replace(/import\.meta\.url/g, 'self.location');
+
+    // Write the modified content back to the file.
+    writeFile(preBundledPickyJs, modifiedData, 'utf8', (err) => {
+        if (err) {
+            console.error('Error writing to the file:', err);
+            return;
+        }
+
+        console.log('File has been modified successfully.');
+    });
+});
+

--- a/ffi/wasm/vite.config.ts
+++ b/ffi/wasm/vite.config.ts
@@ -1,16 +1,29 @@
-import { defineConfig } from 'vite';
-import topLevelAwait from 'vite-plugin-top-level-await';
-import dtsPlugin from 'vite-plugin-dts';
-import wasm from 'vite-plugin-wasm';
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
+import wasm from "vite-plugin-wasm";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 
+// https://vitejs.dev/config/
 export default defineConfig({
   build: {
     lib: {
-      entry: 'main.ts',
-      name: '@Devolutions/picky',
-      formats: ['es'],
+      entry: resolve(__dirname, "main.ts"),
+      name: "Picky",
+      fileName: "picky",
+      formats: ["es", "umd"],
     },
   },
-  assetsInclude: ['pkg/picky_bg.wasm'],
-  plugins: [wasm(), topLevelAwait(), dtsPlugin()],
+  plugins: [
+    wasm(),
+    topLevelAwait(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: "./pkg/picky.d.ts",
+          dest: "./",
+        },
+      ],
+    }),
+  ],
 });


### PR DESCRIPTION
- Update from vite 4 to vite 5
- Adjust package metadata
- Improve dts bundling (single file instead of two)
- Include UMD (Universal Module Definition) too

Package tree before this patch:

```bash
$ tree package
package
├── dist
│   ├── main.d.ts
│   ├── picky.js
│   └── pkg
│       └── picky.d.ts
├── package.json
└── README.md
```

Package tree after this patch:

```bash
$ tree package
package
├── dist
│   ├── picky.d.ts
│   ├── picky.js
│   └── picky.umd.cjs
├── package.json
└── README.md
```