### PR TITLE
chore: prepare releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.8"
+version = "7.0.0-rc.9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "oid",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "base64",
  "lazy_static",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "expect-test",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes",
  "byteorder",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,8 +17,8 @@ embed-resource = "2.4"
 [dependencies]
 picky = { path = "../picky/", default-features = false, features = ["ssh", "x509", "time_conversion", "jose", "pkcs12", "pkcs7", "http_timestamp", "putty"] }
 picky-asn1 = { path = "../picky-asn1", default-features = false }
-picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.12", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
+picky-asn1-der = { path = "../picky-asn1-der" }
+picky-asn1-x509 = { path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
 
 argon2 = "0.5"
 

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -647,7 +647,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",
- "picky 7.0.0-rc.8",
+ "picky 7.0.0-rc.9",
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.8"
+version = "7.0.0-rc.9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "oid",
  "serde",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "picky-asn1",
  "serde",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "num-bigint-dig",

--- a/picky-asn1-der/CHANGELOG.md
+++ b/picky-asn1-der/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.0] 2024-07-12
+
+### Changed
+
+- Bump minimal rustc version to 1.61
+- Update dependencies
+
 ## [0.4.1] 2023-08-23
 
 ### Fixed

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-der"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.61"
 authors = [
@@ -17,7 +17,7 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.8", path = "../picky-asn1" }
+picky-asn1 = { version = "0.9", path = "../picky-asn1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11"
 lazy_static = { version = "1.5", optional = true }

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.13.0] 2024-07-12
+
+### Changed
+
+- Bump minimal rustc version to 1.61
+- Update dependencies
+
 ## [0.12.0] 2023-08-24
 
 ### Added

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-x509"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Sergey Noskov <snoskov@avito.ru>",
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
-picky-asn1 = { version = "0.8", path = "../picky-asn1" }
-picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
+picky-asn1 = { version = "0.9", path = "../picky-asn1" }
+picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
 serde = { version = "1", features = ["derive"] }
 oid = { version = "0.2", features = ["serde_support"] }
 base64 = "0.22"

--- a/picky-asn1/CHANGELOG.md
+++ b/picky-asn1/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.9.0] 2024-07-12
+
+### Changed
+
+- Bump minimal rustc version to 1.61
+- Update dependencies
+
 ## [0.8.0] 2023-08-23
 
 ### Fixed

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.61"
 authors = [

--- a/picky-krb/CHANGELOG.md
+++ b/picky-krb/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] 2024-07-12
+
+### Changed
+
+- Bump minimal rustc version to 1.61
+- Update dependencies
+
 ## [0.8.0] 2023-08-24
 
 ### Fixed

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-krb"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Devolutions Inc."]
 edition = "2021"
 rust-version = "1.60"
@@ -13,9 +13,9 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.8", path = "../picky-asn1" }
-picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.12", path = "../picky-asn1-x509" }
+picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
+picky-asn1-x509 = { version = "0.13", path = "../picky-asn1-x509" }
 serde = { version = "1", features = ["derive"] }
 byteorder = "1.5"
 thiserror = "1"

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.3", path = "../picky-asn1" }
+picky-asn1 = { version = "0.9", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.13", path = "../picky-asn1-x509" }
 serde = { version = "1", features = ["derive"] }

--- a/picky/CHANGELOG.md
+++ b/picky/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Breaking) `PrivateKey` now have private struct representation instead of open enum
 - (Breaking) Now all `PrivateKey::to_public` and all related APIs for private keys return `Result`
   instead of plain `PublicKey`. This change was required because added support for EC/ED keys is not
-  infallible in regards to public key extraction (public key could be missing from the file and could
+  infallible in regard to public key extraction (public key could be missing from the file and could
   not be generated because of an unsupported algorithm/curve)
 
 ### Removed

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "7.0.0-rc.8"
+version = "7.0.0-rc.9"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Jonathan Trepanier <jtrepanier@devolutions.net>",
@@ -21,9 +21,9 @@ repository = "https://github.com/Devolutions/picky-rs"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.8", path = "../picky-asn1", features = ["zeroize"] }
-picky-asn1-der = { version = "0.4", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.12", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
+picky-asn1 = { version = "0.9", path = "../picky-asn1", features = ["zeroize"] }
+picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
+picky-asn1-x509 = { version = "0.13", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22"
 thiserror = "1"


### PR DESCRIPTION
Crates to release:

- picky-asn1 -> 0.9.0
- picky-asn1-der -> 0.5.0
- picky-asn1-x509 -> 0.13.0
- picky-krb -> 0.9.0
- picky -> 7.0.0-rc.9