### PR TITLE
ci: fix success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
   success:
     name: Success
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ always() }}
     needs:
       - formatting
       - lints
@@ -136,4 +136,10 @@ jobs:
 
     steps:
       - name: CI succeeded
+        id: succeeded
+        if: ${{ !contains(needs.*.result, 'failure') }}
         run: exit 0
+
+      - name: CI failed
+        if: ${{ steps.succeeded.outcome == 'skipped' }}
+        run: exit 1


### PR DESCRIPTION
GitHub considers skipped jobs as fulfilling requirements when merging pull requests. We need to ensure that the success job fails if any previous job has failed.