### PR TITLE
ci(nuget): fix build for Android

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -92,7 +92,7 @@ jobs:
         if: matrix.os == 'android'
         shell: pwsh
         run: |    
-          $CargoConfigFile = "~/.cargo/config"
+          $CargoConfigFile = "~/.cargo/config.toml"
           $AndroidToolchain="${Env:ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64"
 
           Get-ChildItem -Path $AndroidToolchain "libunwind.a" -Recurse | ForEach-Object {
@@ -104,8 +104,10 @@ jobs:
             }
           }
 
+          Get-ChildItem -Path "$AndroidToolchain/bin/"
+
           echo "[target.i686-linux-android]" >> $CargoConfigFile
-          echo "linker=`"$AndroidToolchain/bin/i686-linux-android19-clang`"" >> $CargoConfigFile
+          echo "linker=`"$AndroidToolchain/bin/i686-linux-android21-clang`"" >> $CargoConfigFile
           echo "[target.x86_64-linux-android]" >> $CargoConfigFile
           echo "linker=`"$AndroidToolchain/bin/x86_64-linux-android21-clang`"" >> $CargoConfigFile
           echo "[target.armv7-linux-androideabi]" >> $CargoConfigFile


### PR DESCRIPTION
The Android 19 toolchain is not included anymore, so we bump the minimum supported version to Android 21 for i686 (x86) architecture.