### PR TITLE
fix(ffi): remove Pkcs12Mac iterations from FFI interface

### DIFF
--- a/ffi/dotnet/Devolutions.Picky/Generated/Pkcs12MacAlgorithmHmac.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/Pkcs12MacAlgorithmHmac.cs
@@ -73,23 +73,6 @@ public partial class Pkcs12MacAlgorithmHmac: IDisposable
         }
     }
 
-    public uint? Iterations()
-    {
-        unsafe
-        {
-            if (_inner == null)
-            {
-                throw new ObjectDisposedException("Pkcs12MacAlgorithmHmac");
-            }
-            uint* retVal = Raw.Pkcs12MacAlgorithmHmac.Iterations(_inner);
-            if (retVal == null)
-            {
-                return null;
-            }
-            return retVal;
-        }
-    }
-
     /// <summary>
     /// Returns the underlying raw handle.
     /// </summary>

--- a/ffi/dotnet/Devolutions.Picky/Generated/RawPkcs12MacAlgorithmHmac.cs
+++ b/ffi/dotnet/Devolutions.Picky/Generated/RawPkcs12MacAlgorithmHmac.cs
@@ -29,9 +29,6 @@ public partial struct Pkcs12MacAlgorithmHmac
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Pkcs12MacAlgorithmHmac_hash_algorithm", ExactSpelling = true)]
     public static unsafe extern Pkcs12HashAlgorithm HashAlgorithm(Pkcs12MacAlgorithmHmac* self);
 
-    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Pkcs12MacAlgorithmHmac_iterations", ExactSpelling = true)]
-    public static unsafe extern uint* Iterations(Pkcs12MacAlgorithmHmac* self);
-
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "Pkcs12MacAlgorithmHmac_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(Pkcs12MacAlgorithmHmac* self);
 }

--- a/ffi/src/pkcs12.rs
+++ b/ffi/src/pkcs12.rs
@@ -78,10 +78,6 @@ pub mod ffi {
         pub fn hash_algorithm(&self) -> Pkcs12HashAlgorithm {
             self.0.hash_algorithm().into()
         }
-
-        pub fn iterations(&self) -> Option<Box<u32>> {
-            self.0.iterations().map(Box::new)
-        }
     }
 
     #[diplomat::opaque]


### PR DESCRIPTION
The `Iterations` getter on Pkcs12MacAlgorithm doesn't build in dotnet:

> error CS0266: Cannot implicitly convert type 'uint*' to 'uint?'. An explicit conversion exists (are you missing a cast?)

I'm unsure right now how to fix this in diplomat, but the field seems to just be for completeness / an implementation detail. So for now, I remove it from the FFI interface.