### PR TITLE
fix(picky-asn1-x509): improve algorithm identifier parsing

### DIFF
--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -754,18 +754,8 @@ pub enum AesParameters {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct AesAuthEncParams {
-    pub(crate) nonce: OctetStringAsn1,
-    pub(crate) icv_len: IntegerAsn1,
-}
-
-impl AesAuthEncParams {
-    pub fn nonce(&self) -> &[u8] {
-        &self.nonce.0
-    }
-
-    pub fn icv_len(&self) -> &[u8] {
-        &self.icv_len.0
-    }
+    nonce: OctetStringAsn1,
+    icv_len: IntegerAsn1,
 }
 
 impl AesMode {

--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -754,8 +754,18 @@ pub enum AesParameters {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct AesAuthEncParams {
-    pub nonce: OctetStringAsn1,
-    pub icv_len: IntegerAsn1,
+    pub(crate) nonce: OctetStringAsn1,
+    pub(crate) icv_len: IntegerAsn1,
+}
+
+impl AesAuthEncParams {
+    pub fn nonce(&self) -> &[u8] {
+        &self.nonce.0
+    }
+
+    pub fn icv_len(&self) -> &[u8] {
+        &self.icv_len.0
+    }
 }
 
 impl AesMode {


### PR DESCRIPTION
Hi,
In this pull request, I've improved the `AlgorithmIdentifier` parsing. Now, we allow the use of an AES identifier without any parameters.
We need it to parse the `EnvelopedData` structure (I will add it in the next PR).

For example, here is an example of the AES identifier without parameters ([link](https://crypto.qkation.com/asn1/?asn1=a2820402020104308203c40482036c010000004b44534b0300000069010000100000000300000071c278d72590829af6dcb8960b8ad8c5080300001800000018000000444850420001000087a8e61db4b6663cffbbd19c651959998ceef608660dd0f25d2ceed4435e3b00e00df8f1d61957d4faf7df4561b2aa3016c3d91134096faa3bf4296d830e9a7c209e0c6497517abd5a8a9d306bcf67ed91f9e6725b4758c022e0b1ef4275bf7b6c5bfc11d45f9088b941f54eb1e59bb8bc39a0bf12307f5c4fdb70c581b23f76b63acae1caa6b7902d52526735488a0ef13c6d9a51bfa4ab3ad8347796524d8ef6a167b5a41825d967e144e5140564251ccacb83e6b486f6b3ca3f7971506026c0b857f689962856ded4010abd0be621c3a3960a54e710c375f26375d7014103a4b54330c198af126116d2276e11715f693877fad7ef09cadb094ae91e1a15973fb32c9b73134d0b2e77506660edbd484ca7b18f21ef205407f4793a1a0ba12510dbc15077be463fff4fed4aac0bb555be3a6c1b0c6b47b1bc3773bf7e8c6f62901228f8c28cbb18a55ae31341000a650196f931c77a57f2ddf463e5e9ec144b777de62aaab8a8628ac376d282d6ed3864e67982428ebc831d14348f6f2f9193b5045af2767164e1dfc967c1fb3f2e55a4bd1bffe83b9c80d052b985d182ea0adb2a3b7313d3fe14c8484b1e052588b9b7d2bbd2df016199ecd06e1557cd0915b3353bbb64e0ec377fd028370df92b52c7891428cdc67eb6184b523d1db246c32f63078490f00ef8d647d148d47954515e2327cfef98c582664b4c0f6cc416592d30ffafe0b222713779675e39e695e30208d338873f4be4434fb6a8824f1c38414eff304305f301aa83f218d8ae5d59f90cd719f80c92bf2609ef88c5717dde4fb895b4c6b90aa11c354513adc5704917acef5842aaceb9eee49899a3c65e93d47578531e9e0846014986ed4da29338e0e7b31e6e1337fdb07365ab923be32591c89c1421ba082276a27d72e50bca24737c533cfb8d53f4a4d5c5c70282ad16783d3fc46f3cb83a1122a6edfaee1396c07baca246e35aa53a8b7c57c7871e928ecb8585361a36e5867a75cf1fb89444e859845bf62857e10e4a1751e4f192ab6ad3c4dec08e51cfa9b918a1584b8a616f5c2bd6be8c0c7cb1437ded93c3292864006f006d00610069006e002e007400650073007400000064006f006d00610069006e002e0074006500730074000000305206092b0601040182374a013045060a2b0601040182374a01013037303530331303534944132c532d312d352d32312d333333373333373937332d333239373037383032382d3433373338363036362d353132300b060960864801650304012d0428897fc43f748efd095727dde98f4e1a6ffb9d4163d39fb374d049c73d89690c7efa45e6be119e0d6b)):

![image](https://github.com/user-attachments/assets/d670a44f-73f1-41fa-841f-6b333c3ef4f6)
