### PR TITLE
`picky-asn1-x509`: Add protection descriptors OIDs

### DIFF
--- a/picky-asn1-x509/src/oids.rs
+++ b/picky-asn1-x509/src/oids.rs
@@ -266,4 +266,11 @@ define_oid! {
     ATTRIBUTE_PKCS12_LOCAL_KEY_ID => attribute_pkcs12_local_key_id => "1.2.840.113549.1.9.21",
 
     USER_PRINCIPAL_NAME => user_principal_name => "1.3.6.1.4.1.311.20.2.3",
+
+    // Protection descriptor and its types
+    PROTECTION_DESCRIPTOR_TYPE => protection_descriptor_type => "1.3.6.1.4.1.311.74.1",
+    SID_PROTECTION_DESCRIPTOR => sid_protection_descriptor => "1.3.6.1.4.1.311.74.1.1",
+    KEY_FILE_PROTECTION_DESCRIPTOR => key_file_protection_descriptor => "1.3.6.1.4.1.311.74.1.2",
+    SSDL_PROTECTION_DESCRIPTOR => ssdl_protection_descriptor => "1.3.6.1.4.1.311.74.1.5",
+    LOCAL_PROTECTION_DESCRIPTOR => local_protection_descriptor => "1.3.6.1.4.1.311.74.1.8",
 }


### PR DESCRIPTION
Hi,
In this pull request, I've added protection descriptors OIDs. There is no public documentation about them. I took the values from the `dpapi-ng` code: https://github.com/jborean93/dpapi-ng/blob/57143c31897e647d97f5a8b505188dc447025997/src/dpapi_ng/_blob.py#L128-L132.

We need those values to construct and parse DPAPI blobs.