### PR TITLE
chore: prepare releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.9"
+version = "7.0.0-rc.10"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "expect-test",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes",
  "byteorder",

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -667,7 +667,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",
- "picky 7.0.0-rc.9",
+ "picky 7.0.0-rc.10",
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.9"
+version = "7.0.0-rc.10"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "num-bigint-dig",

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.14.0] 2024-11-19
+
+### Added
+
+- `EnvelopedData` and related structures
+- API to query and set MAC algorithm for PFX
+- Protection descriptors OIDs
+
+### Fixed
+
+- Better algorithm identifier parsing
+
 ## [0.13.0] 2024-07-12
 
 ### Changed

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-x509"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Sergey Noskov <snoskov@avito.ru>",

--- a/picky-krb/CHANGELOG.md
+++ b/picky-krb/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] 2024-11-19
+
+### Changed
+
+- Update dependencies
+
 ## [0.9.0] 2024-07-12
 
 ### Changed

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-krb"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Devolutions Inc."]
 edition = "2021"
 rust-version = "1.60"
@@ -15,7 +15,7 @@ include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 [dependencies]
 picky-asn1 = { version = "0.9", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.13", path = "../picky-asn1-x509" }
+picky-asn1-x509 = { version = "0.14", path = "../picky-asn1-x509" }
 serde = { version = "1", features = ["derive"] }
 byteorder = "1.5"
 thiserror = "1"

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "7.0.0-rc.9"
+version = "7.0.0-rc.10"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Jonathan Trepanier <jtrepanier@devolutions.net>",
@@ -23,7 +23,7 @@ include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 [dependencies]
 picky-asn1 = { version = "0.9", path = "../picky-asn1", features = ["zeroize"] }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
-picky-asn1-x509 = { version = "0.13", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
+picky-asn1-x509 = { version = "0.14", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
 serde = { version = "1", features = ["derive"] }
 base64 = "0.22"
 thiserror = "1"


### PR DESCRIPTION
Crates to release:

- picky-asn1-x509 -> 0.14.0
- picky-krb -> 0.9.1
- picky -> 7.0.0-rc.10