### PR TITLE
chore: prepare releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.10"
+version = "7.0.0-rc.11"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "oid",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "lazy_static",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "expect-test",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes",
  "byteorder",

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -667,7 +667,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",
- "picky 7.0.0-rc.10",
+ "picky 7.0.0-rc.11",
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.10"
+version = "7.0.0-rc.11"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "oid",
  "serde",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "picky-asn1",
  "serde",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "num-bigint-dig",

--- a/picky-asn1-der/CHANGELOG.md
+++ b/picky-asn1-der/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.1] 2024-11-26
+
+### Changed
+
+- Update dependencies
+
 ## [0.5.0] 2024-07-12
 
 ### Changed

--- a/picky-asn1-der/Cargo.toml
+++ b/picky-asn1-der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-der"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.61"
 authors = [
@@ -17,7 +17,7 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.9", path = "../picky-asn1" }
+picky-asn1 = { version = "0.10", path = "../picky-asn1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11"
 lazy_static = { version = "1.5", optional = true }

--- a/picky-asn1-x509/CHANGELOG.md
+++ b/picky-asn1-x509/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.14.1] 2024-11-26
+
 ### Changed
 
-- "picky-test-data" is a new dev-dependency.
+- `picky-test-data` is a new dev-dependency.
+- Update dependencies.
 
 ## [0.14.0] 2024-11-19
 

--- a/picky-asn1-x509/Cargo.toml
+++ b/picky-asn1-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1-x509"
-version = "0.14.0"
+version = "0.14.1"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Sergey Noskov <snoskov@avito.ru>",
@@ -17,7 +17,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Devolutions/picky-rs"
 
 [dependencies]
-picky-asn1 = { version = "0.9", path = "../picky-asn1" }
+picky-asn1 = { version = "0.10", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
 serde = { version = "1", features = ["derive"] }
 oid = { version = "0.2", features = ["serde_support"] }

--- a/picky-asn1/CHANGELOG.md
+++ b/picky-asn1/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.10.0] 2024-11-26
+
 ### Fixed
 
-- "picky-asn1-der" is now a dev-dependency of the released crate, to fix test build.
+- `picky-asn1-der` is now a dev-dependency of the released crate, to fix test build.
 
 ### Changed
 

--- a/picky-asn1/Cargo.toml
+++ b/picky-asn1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-asn1"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.61"
 authors = [

--- a/picky-krb/CHANGELOG.md
+++ b/picky-krb/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] 2024-11-26
+
+### Changed
+
+- Update dependencies
+
 ## [0.9.1] 2024-11-19
 
 ### Changed

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky-krb"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Devolutions Inc."]
 edition = "2021"
 rust-version = "1.60"
@@ -13,7 +13,7 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.9", path = "../picky-asn1" }
+picky-asn1 = { version = "0.10", path = "../picky-asn1" }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.14", path = "../picky-asn1-x509" }
 serde = { version = "1", features = ["derive"] }

--- a/picky-server/Cargo.toml
+++ b/picky-server/Cargo.toml
@@ -15,8 +15,8 @@ publish = false
 # picky-server has been discontinued, so this crate is not in the main workspace anymore
 
 [dependencies]
-picky = { version = "7.0.0-rc.8", default-features = false, features = ["x509", "jose", "pkcs7", "ssh", "time_conversion" ], path = "../picky" }
-picky-asn1 = { version = "0.9", path = "../picky-asn1" }
+picky = { version = "7.0.0-rc.10", default-features = false, features = ["x509", "jose", "pkcs7", "ssh", "time_conversion" ], path = "../picky" }
+picky-asn1 = { version = "0.10", path = "../picky-asn1" }
 mongodm = { version = "0.8", features = ["tokio-runtime"] }
 clap = { version = "2.33", features = ["yaml"] }
 saphir = { version = "2.8", features = ["macro"] }

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picky"
-version = "7.0.0-rc.10"
+version = "7.0.0-rc.11"
 authors = [
     "Benoît CORTIER <bcortier@devolutions.net>",
     "Jonathan Trepanier <jtrepanier@devolutions.net>",

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/Devolutions/picky-rs"
 include = ["src/**/*", "README.md", "CHANGELOG.md", "LICENSE-*"]
 
 [dependencies]
-picky-asn1 = { version = "0.9", path = "../picky-asn1", features = ["zeroize"] }
+picky-asn1 = { version = "0.10", path = "../picky-asn1", features = ["zeroize"] }
 picky-asn1-der = { version = "0.5", path = "../picky-asn1-der" }
 picky-asn1-x509 = { version = "0.14", path = "../picky-asn1-x509", features = ["legacy", "zeroize"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Crates to release:

- picky-test-data -> 0.1.0
- picky-asn1 -> 0.10.0
- picky-asn1-der -> 0.5.1
- picky-asn1-x509 -> 0.14.1
- picky-krb -> 0.9.2
- picky -> 7.0.0-rc.11