### PR TITLE
fix: symlinks to license files in packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,3 @@ package/
 c-api/examples/out
 picky_server_conf.yaml
 .DS_Store
-
-**/LICENSE-MIT
-**/LICENSE-APACHE
-!/LICENSE-MIT
-!/LICENSE-APACHE

--- a/copy-license-files.ps1
+++ b/copy-license-files.ps1
@@ -1,9 +1,0 @@
-$WorkspacePath = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
-Get-ChildItem Cargo.toml -Recurse | ForEach-Object {
-    $CratePath = $_.Directory.FullName
-    if ($CratePath -ne $WorkspacePath) {
-        foreach ($LicenseFile in @('LICENSE-APACHE', 'LICENSE-MIT')) {
-            Copy-Item -Path $LicenseFile -Destination (Join-Path $CratePath $LicenseFile) -Force
-        }
-    }
-}

--- a/picky-asn1-der/LICENSE-APACHE
+++ b/picky-asn1-der/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1-der/LICENSE-MIT
+++ b/picky-asn1-der/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-asn1-x509/LICENSE-APACHE
+++ b/picky-asn1-x509/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1-x509/LICENSE-MIT
+++ b/picky-asn1-x509/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-asn1/LICENSE-APACHE
+++ b/picky-asn1/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-asn1/LICENSE-MIT
+++ b/picky-asn1/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-krb/LICENSE-APACHE
+++ b/picky-krb/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-krb/LICENSE-MIT
+++ b/picky-krb/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky-test-data/LICENSE-APACHE
+++ b/picky-test-data/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky-test-data/LICENSE-MIT
+++ b/picky-test-data/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/picky/LICENSE-APACHE
+++ b/picky/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/picky/LICENSE-MIT
+++ b/picky/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Use symlinks instead of copying files to avoid a “dirty” state during cargo publish and preserve VCS info. With #337 merged, CI handles publishing consistently, so developer environments no longer matter.