### PR TITLE
feat(picky-krb): implement Kerberos encryption without a checksum

### DIFF
--- a/picky-krb/src/crypto/aes/aes256_cts_hmac_sha1_96.rs
+++ b/picky-krb/src/crypto/aes/aes256_cts_hmac_sha1_96.rs
@@ -1,10 +1,13 @@
 use rand::rngs::OsRng;
 use rand::Rng;
 
-use crate::crypto::{Cipher, CipherSuite, KerberosCryptoError, KerberosCryptoResult};
+use crate::crypto::{
+    ChecksumSuite, Cipher, CipherSuite, DecryptWithoutChecksum, EncryptWithoutChecksum, KerberosCryptoError,
+    KerberosCryptoResult,
+};
 
-use super::decrypt::decrypt_message;
-use super::encrypt::encrypt_message;
+use super::decrypt::{decrypt_message, decrypt_message_no_checksum};
+use super::encrypt::{encrypt_message, encrypt_message_no_checksum};
 use super::key_derivation::random_to_key;
 use super::{derive_key_from_password, AesSize, AES256_KEY_SIZE, AES_BLOCK_SIZE};
 
@@ -26,6 +29,10 @@ impl Cipher for Aes256CtsHmacSha196 {
         CipherSuite::Aes256CtsHmacSha196
     }
 
+    fn checksum_type(&self) -> ChecksumSuite {
+        ChecksumSuite::HmacSha196Aes256
+    }
+
     fn encrypt(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> Result<Vec<u8>, KerberosCryptoError> {
         encrypt_message(
             key,
@@ -36,8 +43,32 @@ impl Cipher for Aes256CtsHmacSha196 {
         )
     }
 
+    fn encrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        payload: &[u8],
+    ) -> KerberosCryptoResult<EncryptWithoutChecksum> {
+        encrypt_message_no_checksum(
+            key,
+            key_usage,
+            payload,
+            &AesSize::Aes256,
+            OsRng.gen::<[u8; AES_BLOCK_SIZE]>(),
+        )
+    }
+
     fn decrypt(&self, key: &[u8], key_usage: i32, cipher_data: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
         decrypt_message(key, key_usage, cipher_data, &AesSize::Aes256)
+    }
+
+    fn decrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        cipher_data: &[u8],
+    ) -> KerberosCryptoResult<DecryptWithoutChecksum> {
+        decrypt_message_no_checksum(key, key_usage, cipher_data, &AesSize::Aes256)
     }
 
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
@@ -55,9 +86,11 @@ impl Cipher for Aes256CtsHmacSha196 {
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::aes::decrypt::decrypt_message;
-    use crate::crypto::aes::encrypt::encrypt_message;
-    use crate::crypto::aes::AesSize;
+    use crate::crypto::aes::decrypt::{decrypt_message, decrypt_message_no_checksum};
+    use crate::crypto::aes::encrypt::{encrypt_message, encrypt_message_no_checksum};
+    use crate::crypto::aes::{AesSize, AES_MAC_SIZE};
+    use crate::crypto::common::hmac_sha1;
+    use crate::crypto::{DecryptWithoutChecksum, EncryptWithoutChecksum};
 
     fn encrypt(plaintext: &[u8]) -> Vec<u8> {
         let key = [
@@ -77,6 +110,24 @@ mod tests {
         .unwrap()
     }
 
+    fn encrypt_no_checksum(plaintext: &[u8]) -> EncryptWithoutChecksum {
+        let key = [
+            22, 151, 234, 93, 29, 64, 176, 109, 232, 140, 95, 54, 168, 107, 20, 251, 155, 71, 70, 148, 50, 145, 49,
+            157, 182, 139, 235, 19, 11, 199, 3, 135,
+        ];
+
+        encrypt_message_no_checksum(
+            &key,
+            5,
+            plaintext,
+            &AesSize::Aes256,
+            [
+                161, 52, 157, 33, 238, 232, 185, 93, 167, 130, 91, 180, 167, 165, 224, 78,
+            ],
+        )
+        .unwrap()
+    }
+
     fn decrypt(payload: &[u8]) -> Vec<u8> {
         let key = [
             22, 151, 234, 93, 29, 64, 176, 109, 232, 140, 95, 54, 168, 107, 20, 251, 155, 71, 70, 148, 50, 145, 49,
@@ -84,6 +135,15 @@ mod tests {
         ];
 
         decrypt_message(&key, 5, payload, &AesSize::Aes256).unwrap()
+    }
+
+    fn decrypt_no_checksum(payload: &[u8]) -> DecryptWithoutChecksum {
+        let key = [
+            22, 151, 234, 93, 29, 64, 176, 109, 232, 140, 95, 54, 168, 107, 20, 251, 155, 71, 70, 148, 50, 145, 49,
+            157, 182, 139, 235, 19, 11, 199, 3, 135,
+        ];
+
+        decrypt_message_no_checksum(&key, 5, payload, &AesSize::Aes256).unwrap()
     }
 
     #[test]
@@ -325,6 +385,68 @@ mod tests {
                 112, 116, 111, 46, 114, 115, 46, 112, 105, 99, 107, 121, 45, 114, 115, 46
             ],
             decrypt(&payload).as_slice()
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_no_checksum() {
+        // three blocks
+        let plaintext = [
+            97, 101, 115, 50, 53, 54, 95, 99, 116, 115, 95, 104, 109, 97, 99, 95, 115, 104, 97, 49, 95, 57, 54, 46,
+            107, 101, 121, 95, 100, 101, 114, 105, 118, 97, 116, 105, 111, 110, 46, 114, 115, 46, 99, 114, 121, 112,
+            116, 111,
+        ];
+
+        let expected_encrypted = &[
+            214, 122, 109, 174, 37, 138, 242, 223, 137, 137, 242, 93, 162, 124, 121, 114, 10, 164, 28, 60, 222, 116,
+            184, 67, 131, 207, 244, 3, 10, 249, 22, 244, 35, 238, 183, 171, 208, 35, 185, 212, 190, 49, 9, 49, 122,
+            105, 47, 155, 81, 226, 246, 250, 147, 120, 239, 83, 65, 157, 252, 73, 142, 130, 107, 70, 233, 12, 140, 124,
+            156, 243, 171, 176, 162, 128, 119, 189,
+        ];
+
+        assert_eq!(expected_encrypted, encrypt(&plaintext).as_slice());
+
+        let expected_encrypted_no_checksum = &expected_encrypted[0..expected_encrypted.len() - AES_MAC_SIZE];
+
+        let encryption_result = encrypt_no_checksum(&plaintext);
+        assert_eq!(expected_encrypted_no_checksum, encryption_result.encrypted);
+
+        // prepare for checksum calculation
+        let mut conf_and_plaintext = encryption_result.confounder.clone();
+        conf_and_plaintext.extend_from_slice(&plaintext);
+
+        // verify that the same checksum is generated
+        assert_eq!(
+            hmac_sha1(&encryption_result.ki, &conf_and_plaintext, AES_MAC_SIZE),
+            expected_encrypted[expected_encrypted.len() - AES_MAC_SIZE..]
+        );
+
+        // verify that concatenating encrypted data and checksum gives expected result
+        let mut encrypted_with_checksum = encryption_result.encrypted;
+        encrypted_with_checksum.extend(&hmac_sha1(&encryption_result.ki, &conf_and_plaintext, AES_MAC_SIZE));
+        assert_eq!(encrypted_with_checksum, expected_encrypted);
+
+        // verify that decrypt functions produce the same result
+        let decryption_result = decrypt_no_checksum(expected_encrypted);
+        assert_eq!(decrypt(expected_encrypted), decryption_result.plaintext);
+
+        assert_eq!(decryption_result.confounder, encryption_result.confounder);
+
+        assert_eq!(
+            decryption_result.checksum,
+            expected_encrypted[expected_encrypted.len() - AES_MAC_SIZE..]
+        );
+
+        // generate checksum and validate it against the actual
+        let mut decrypted_confounder_with_plaintext = decryption_result.confounder.clone();
+        decrypted_confounder_with_plaintext.extend(decryption_result.plaintext);
+        assert_eq!(
+            hmac_sha1(
+                &decryption_result.ki,
+                &decrypted_confounder_with_plaintext,
+                AES_MAC_SIZE
+            ),
+            decryption_result.checksum
         );
     }
 }

--- a/picky-krb/src/crypto/aes/decrypt.rs
+++ b/picky-krb/src/crypto/aes/decrypt.rs
@@ -4,7 +4,7 @@ use aes::{Aes128, Aes256};
 
 use crate::crypto::common::hmac_sha1;
 use crate::crypto::utils::{usage_ke, usage_ki};
-use crate::crypto::{KerberosCryptoError, KerberosCryptoResult};
+use crate::crypto::{DecryptWithoutChecksum, KerberosCryptoError, KerberosCryptoResult};
 
 use super::key_derivation::derive_key;
 use super::{swap_two_last_blocks, AesSize, AES_BLOCK_SIZE, AES_MAC_SIZE};
@@ -19,6 +19,32 @@ pub fn decrypt_message(
     cipher_data: &[u8],
     aes_size: &AesSize,
 ) -> KerberosCryptoResult<Vec<u8>> {
+    let decryption_result = decrypt_message_no_checksum(key, key_usage, cipher_data, aes_size)?;
+    let calculated_checksum = hmac_sha1(
+        &decryption_result.ki,
+        &[
+            decryption_result.confounder.as_slice(),
+            decryption_result.plaintext.as_slice(),
+        ]
+        .concat(),
+        AES_MAC_SIZE,
+    );
+
+    // if (H1 != HMAC(Ki, P1)[1..h])
+    if calculated_checksum != decryption_result.checksum {
+        return Err(KerberosCryptoError::IntegrityCheck);
+    }
+
+    Ok(decryption_result.plaintext)
+}
+
+/// Returns (Plaintext, conf, H1, Ki)
+pub fn decrypt_message_no_checksum(
+    key: &[u8],
+    key_usage: i32,
+    cipher_data: &[u8],
+    aes_size: &AesSize,
+) -> KerberosCryptoResult<DecryptWithoutChecksum> {
     if cipher_data.len() < AES_BLOCK_SIZE + AES_MAC_SIZE {
         return Err(KerberosCryptoError::CipherLength(
             cipher_data.len(),
@@ -34,15 +60,14 @@ pub fn decrypt_message(
     let plaintext = decrypt_aes_cts(&ke, cipher_data, aes_size)?;
 
     let ki = derive_key(key, &usage_ki(key_usage), aes_size)?;
-    let calculated_checksum = hmac_sha1(&ki, &plaintext, AES_MAC_SIZE);
 
-    // if (H1 != HMAC(Ki, P1)[1..h])
-    if calculated_checksum != checksum {
-        return Err(KerberosCryptoError::IntegrityCheck);
-    }
-
-    // [0..AES_BLOCK_SIZE] = the first block is a random confounder bytes. skip them
-    Ok(plaintext[AES_BLOCK_SIZE..].to_vec())
+    Ok(DecryptWithoutChecksum {
+        // [0..AES_BLOCK_SIZE] = the first block is a random confounder bytes. skip them
+        plaintext: plaintext[AES_BLOCK_SIZE..].to_vec(),
+        confounder: plaintext[0..AES_BLOCK_SIZE].to_vec(),
+        checksum: checksum.to_vec(),
+        ki,
+    })
 }
 
 pub fn decrypt_aes_cbc(key: &[u8], cipher_data: &[u8], aes_size: &AesSize) -> KerberosCryptoResult<Vec<u8>> {

--- a/picky-krb/src/crypto/aes/decrypt.rs
+++ b/picky-krb/src/crypto/aes/decrypt.rs
@@ -61,10 +61,12 @@ pub fn decrypt_message_no_checksum(
 
     let ki = derive_key(key, &usage_ki(key_usage), aes_size)?;
 
+    // [0..AES_BLOCK_SIZE] = the first block is a random confounder bytes.
+    let (confounder, plaintext) = plaintext.split_at(AES_BLOCK_SIZE);
+
     Ok(DecryptWithoutChecksum {
-        // [0..AES_BLOCK_SIZE] = the first block is a random confounder bytes. skip them
-        plaintext: plaintext[AES_BLOCK_SIZE..].to_vec(),
-        confounder: plaintext[0..AES_BLOCK_SIZE].to_vec(),
+        plaintext: plaintext.to_vec(),
+        confounder: confounder.to_vec(),
         checksum: checksum.to_vec(),
         ki,
     })

--- a/picky-krb/src/crypto/aes/encrypt.rs
+++ b/picky-krb/src/crypto/aes/encrypt.rs
@@ -24,10 +24,11 @@ pub fn encrypt_message(
 ) -> KerberosCryptoResult<Vec<u8>> {
     let mut encryption_result = encrypt_message_no_checksum(key, key_usage, payload, aes_size, confounder)?;
     // prepare for checksum generation
-    let mut data_to_encrypt = vec![0; aes_size.confounder_byte_size() + payload.len()];
+    let mut data_to_encrypt = vec![0; AES_BLOCK_SIZE + payload.len()];
 
-    data_to_encrypt[0..aes_size.confounder_byte_size()].copy_from_slice(&confounder);
-    data_to_encrypt[aes_size.confounder_byte_size()..].copy_from_slice(payload);
+    let (confounder_buf, payload_buf) = data_to_encrypt.split_at_mut(AES_BLOCK_SIZE);
+    confounder_buf.copy_from_slice(&confounder);
+    payload_buf.copy_from_slice(payload);
 
     // H1 = HMAC(Ki, conf | plaintext | pad)
     let hmac = hmac_sha1(&encryption_result.ki, &data_to_encrypt, AES_MAC_SIZE);
@@ -51,10 +52,11 @@ pub fn encrypt_message_no_checksum(
         return Err(KerberosCryptoError::KeyLength(key.len(), aes_size.key_length()));
     }
 
-    let mut data_to_encrypt = vec![0; aes_size.confounder_byte_size() + payload.len()];
+    let mut data_to_encrypt = vec![0; AES_BLOCK_SIZE + payload.len()];
 
-    data_to_encrypt[0..aes_size.confounder_byte_size()].copy_from_slice(&confounder);
-    data_to_encrypt[aes_size.confounder_byte_size()..].copy_from_slice(payload);
+    let (confounder_buf, payload_buf) = data_to_encrypt.split_at_mut(AES_BLOCK_SIZE);
+    confounder_buf.copy_from_slice(&confounder);
+    payload_buf.copy_from_slice(payload);
 
     let ke = derive_key(key, &usage_ke(key_usage), aes_size)?;
     // (C1, newIV) = E(Ke, conf | plaintext | pad, oldstate.ivec)
@@ -96,7 +98,7 @@ pub fn encrypt_aes_cts(key: &[u8], payload: &[u8], aes_size: &AesSize) -> Kerber
     let pad_length = (AES_BLOCK_SIZE - (payload.len() % AES_BLOCK_SIZE)) % AES_BLOCK_SIZE;
 
     let mut padded_payload = payload.to_vec();
-    padded_payload.extend_from_slice(&vec![0; pad_length]);
+    padded_payload.resize(padded_payload.len() + pad_length, 0);
 
     let mut cipher = encrypt_aes_cbc(key, &padded_payload, aes_size)?;
 

--- a/picky-krb/src/crypto/aes/encrypt.rs
+++ b/picky-krb/src/crypto/aes/encrypt.rs
@@ -6,7 +6,7 @@ use cbc::Encryptor;
 use crate::crypto::aes::key_derivation::derive_key;
 use crate::crypto::common::hmac_sha1;
 use crate::crypto::utils::{usage_ke, usage_ki};
-use crate::crypto::{KerberosCryptoError, KerberosCryptoResult};
+use crate::crypto::{EncryptWithoutChecksum, KerberosCryptoError, KerberosCryptoResult};
 
 use super::{swap_two_last_blocks, AesSize, AES_BLOCK_SIZE, AES_MAC_SIZE};
 
@@ -22,6 +22,31 @@ pub fn encrypt_message(
     // conf = Random string of length c
     confounder: [u8; AES_BLOCK_SIZE],
 ) -> KerberosCryptoResult<Vec<u8>> {
+    let mut encryption_result = encrypt_message_no_checksum(key, key_usage, payload, aes_size, confounder)?;
+    // prepare for checksum generation
+    let mut data_to_encrypt = vec![0; aes_size.confounder_byte_size() + payload.len()];
+
+    data_to_encrypt[0..aes_size.confounder_byte_size()].copy_from_slice(&confounder);
+    data_to_encrypt[aes_size.confounder_byte_size()..].copy_from_slice(payload);
+
+    // H1 = HMAC(Ki, conf | plaintext | pad)
+    let hmac = hmac_sha1(&encryption_result.ki, &data_to_encrypt, AES_MAC_SIZE);
+
+    // ciphertext =  C1 | H1[1..h]
+    encryption_result.encrypted.extend_from_slice(&hmac);
+
+    Ok(encryption_result.encrypted)
+}
+
+/// Returns (C1, conf, Ki)
+pub fn encrypt_message_no_checksum(
+    key: &[u8],
+    key_usage: i32,
+    payload: &[u8],
+    aes_size: &AesSize,
+    // conf = Random string of length c
+    confounder: [u8; AES_BLOCK_SIZE],
+) -> KerberosCryptoResult<EncryptWithoutChecksum> {
     if key.len() != aes_size.key_length() {
         return Err(KerberosCryptoError::KeyLength(key.len(), aes_size.key_length()));
     }
@@ -33,16 +58,15 @@ pub fn encrypt_message(
 
     let ke = derive_key(key, &usage_ke(key_usage), aes_size)?;
     // (C1, newIV) = E(Ke, conf | plaintext | pad, oldstate.ivec)
-    let mut encrypted = encrypt_aes_cts(&ke, &data_to_encrypt, aes_size)?;
+    let encrypted = encrypt_aes_cts(&ke, &data_to_encrypt, aes_size)?;
 
     let ki = derive_key(key, &usage_ki(key_usage), aes_size)?;
-    // H1 = HMAC(Ki, conf | plaintext | pad)
-    let hmac = hmac_sha1(&ki, &data_to_encrypt, AES_MAC_SIZE);
 
-    // ciphertext =  C1 | H1[1..h]
-    encrypted.extend_from_slice(&hmac);
-
-    Ok(encrypted)
+    Ok(EncryptWithoutChecksum {
+        encrypted,
+        confounder: confounder.to_vec(),
+        ki,
+    })
 }
 
 pub fn encrypt_aes_cbc(key: &[u8], plaintext: &[u8], aes_size: &AesSize) -> KerberosCryptoResult<Vec<u8>> {

--- a/picky-krb/src/crypto/aes/mod.rs
+++ b/picky-krb/src/crypto/aes/mod.rs
@@ -12,10 +12,10 @@ use super::{KerberosCryptoError, KerberosCryptoResult};
 
 /// [Kerberos Algorithm Profile Parameters](https://www.rfc-editor.org/rfc/rfc3962.html#section-6)
 /// cipher block size 16 octets
-const AES_BLOCK_SIZE: usize = 16;
+pub const AES_BLOCK_SIZE: usize = 16;
 /// [Kerberos Algorithm Profile Parameters](https://www.rfc-editor.org/rfc/rfc3962.html#section-6)
 /// HMAC output size = 12 octets
-const AES_MAC_SIZE: usize = 12;
+pub const AES_MAC_SIZE: usize = 12;
 
 /// [Assigned Numbers](https://www.rfc-editor.org/rfc/rfc3962.html#section-7)
 pub const AES128_KEY_SIZE: usize = 128 / 8;

--- a/picky-krb/src/crypto/aes/mod.rs
+++ b/picky-krb/src/crypto/aes/mod.rs
@@ -45,10 +45,6 @@ impl AesSize {
     pub fn seed_bit_len(&self) -> usize {
         self.key_length() * 8
     }
-
-    fn confounder_byte_size(&self) -> usize {
-        AES_BLOCK_SIZE
-    }
 }
 
 pub fn swap_two_last_blocks(data: &mut [u8]) -> KerberosCryptoResult<()> {

--- a/picky-krb/src/crypto/cipher.rs
+++ b/picky-krb/src/crypto/cipher.rs
@@ -2,15 +2,29 @@ use crate::constants::etypes::{AES128_CTS_HMAC_SHA1_96, AES256_CTS_HMAC_SHA1_96,
 
 use super::aes::{Aes128CtsHmacSha196, Aes256CtsHmacSha196};
 use super::des::Des3CbcSha1Kd;
-use super::{KerberosCryptoError, KerberosCryptoResult};
+use super::{ChecksumSuite, DecryptWithoutChecksum, EncryptWithoutChecksum, KerberosCryptoError, KerberosCryptoResult};
 
 pub trait Cipher {
     fn key_size(&self) -> usize;
     fn seed_bit_len(&self) -> usize;
     fn cipher_type(&self) -> CipherSuite;
+    fn checksum_type(&self) -> ChecksumSuite;
 
     fn encrypt(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
     fn decrypt(&self, key: &[u8], key_usage: i32, cipher_data: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
+
+    fn encrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        payload: &[u8],
+    ) -> KerberosCryptoResult<EncryptWithoutChecksum>;
+    fn decrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        cipher_data: &[u8],
+    ) -> KerberosCryptoResult<DecryptWithoutChecksum>;
 
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
     fn random_to_key(&self, key: Vec<u8>) -> Vec<u8>;

--- a/picky-krb/src/crypto/common.rs
+++ b/picky-krb/src/crypto/common.rs
@@ -3,11 +3,10 @@ use sha1::Sha1;
 
 //= [Checksum Profiles Based on Simplified Profile](https://datatracker.ietf.org/doc/html/rfc3961#section-5.4) =//
 pub fn hmac_sha1(key: &[u8], payload: &[u8], mac_size: usize) -> Vec<u8> {
-    let key_len = key.len();
     let mut key = key.to_vec();
 
     // this Hmac implementation requires 64-byte key
-    key.extend_from_slice(&vec![0; 64 - key_len]);
+    key.resize(64, 0);
 
     let mut hmacker = Hmac::<Sha1>::new(key.as_slice().into());
 

--- a/picky-krb/src/crypto/des/decrypt.rs
+++ b/picky-krb/src/crypto/des/decrypt.rs
@@ -50,10 +50,12 @@ pub fn decrypt_message_no_checksum(
 
     let ki = derive_key(key, &usage_ki(key_usage))?;
 
+    // [0..DES3_BLOCK_SIZE] = the first block is random confounder bytes.
+    let (confounder, plaintext) = plaintext.split_at(DES3_BLOCK_SIZE);
+
     Ok(DecryptWithoutChecksum {
-        // [0..DES3_BLOCK_SIZE] = the first block is random confounder bytes. skip them
-        plaintext: plaintext[DES3_BLOCK_SIZE..].to_vec(),
-        confounder: plaintext[0..DES3_BLOCK_SIZE].to_vec(),
+        plaintext: plaintext.to_vec(),
+        confounder: confounder.to_vec(),
         checksum: checksum.to_vec(),
         ki,
     })

--- a/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
+++ b/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
@@ -145,7 +145,7 @@ mod tests {
         let mut conf_with_plaintext: Vec<u8> = encryption_result.confounder;
         conf_with_plaintext.extend_from_slice(&plaintext);
         let pad_len = (DES3_BLOCK_SIZE - (conf_with_plaintext.len() % DES3_BLOCK_SIZE)) % DES3_BLOCK_SIZE;
-        conf_with_plaintext.extend_from_slice(&vec![0; pad_len]);
+        conf_with_plaintext.resize(conf_with_plaintext.len() + pad_len, 0);
 
         assert_eq!(
             hmac_sha1(&encryption_result.ki, &conf_with_plaintext, DES3_MAC_SIZE),

--- a/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
+++ b/picky-krb/src/crypto/des/des3_cbc_sha1_kd.rs
@@ -1,10 +1,12 @@
 use rand::rngs::OsRng;
 use rand::Rng;
 
-use crate::crypto::{Cipher, CipherSuite, KerberosCryptoResult};
+use crate::crypto::{
+    ChecksumSuite, Cipher, CipherSuite, DecryptWithoutChecksum, EncryptWithoutChecksum, KerberosCryptoResult,
+};
 
-use super::decrypt::decrypt_message;
-use super::encrypt::encrypt_message;
+use super::decrypt::{decrypt_message, decrypt_message_no_checksum};
+use super::encrypt::{encrypt_message, encrypt_message_no_checksum};
 use super::key_derivation::random_to_key;
 use super::{derive_key_from_password, DES3_BLOCK_SIZE, DES3_KEY_SIZE, DES3_SEED_LEN};
 
@@ -34,12 +36,34 @@ impl Cipher for Des3CbcSha1Kd {
         CipherSuite::Des3CbcSha1Kd
     }
 
+    fn checksum_type(&self) -> ChecksumSuite {
+        ChecksumSuite::HmacSha1Des3Kd
+    }
+
     fn encrypt(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
         encrypt_message(key, key_usage, payload, OsRng.gen::<[u8; DES3_BLOCK_SIZE]>())
     }
 
+    fn encrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        payload: &[u8],
+    ) -> KerberosCryptoResult<EncryptWithoutChecksum> {
+        encrypt_message_no_checksum(key, key_usage, payload, OsRng.gen::<[u8; DES3_BLOCK_SIZE]>())
+    }
+
     fn decrypt(&self, key: &[u8], key_usage: i32, cipher_data: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
         decrypt_message(key, key_usage, cipher_data)
+    }
+
+    fn decrypt_no_checksum(
+        &self,
+        key: &[u8],
+        key_usage: i32,
+        cipher_data: &[u8],
+    ) -> KerberosCryptoResult<DecryptWithoutChecksum> {
+        decrypt_message_no_checksum(key, key_usage, cipher_data)
     }
 
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
@@ -49,8 +73,10 @@ impl Cipher for Des3CbcSha1Kd {
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::des::decrypt::decrypt_message;
-    use crate::crypto::des::encrypt::encrypt_message;
+    use crate::crypto::common::hmac_sha1;
+    use crate::crypto::des::decrypt::{decrypt_message, decrypt_message_no_checksum};
+    use crate::crypto::des::encrypt::{encrypt_message, encrypt_message_no_checksum};
+    use crate::crypto::des::{DES3_BLOCK_SIZE, DES3_MAC_SIZE};
 
     #[test]
     fn encrypt() {
@@ -92,6 +118,81 @@ mod tests {
         assert_eq!(
             &[97, 101, 115, 50, 53, 54, 95, 99, 116, 115, 95, 104, 109, 97, 99, 95, 115, 104, 97, 49, 95, 57, 54, 0],
             plaintext.as_slice()
+        );
+    }
+
+    #[test]
+    fn encrypt_no_checksum() {
+        let key = [
+            115, 248, 21, 32, 230, 42, 157, 138, 158, 254, 157, 145, 13, 110, 64, 107, 173, 206, 247, 93, 55, 146, 167,
+            138,
+        ];
+        let plaintext = [
+            97, 101, 115, 50, 53, 54, 95, 99, 116, 115, 95, 104, 109, 97, 99, 95, 115, 104, 97, 49, 95, 57, 54,
+        ];
+        let confounder = [161, 52, 157, 33, 238, 232, 185, 93];
+
+        let encryption_result = encrypt_message_no_checksum(&key, 5, &plaintext, confounder).unwrap();
+
+        assert_eq!(confounder, encryption_result.confounder.as_slice());
+
+        let expected_encrypted_data_with_checksum = &[
+            126, 136, 43, 80, 62, 251, 57, 122, 225, 31, 122, 177, 228, 203, 192, 209, 209, 50, 207, 26, 25, 42, 111,
+            102, 243, 28, 130, 32, 30, 129, 155, 136, 93, 10, 246, 56, 89, 215, 120, 254, 207, 136, 121, 74, 156, 20,
+            56, 227, 234, 98, 203, 221,
+        ];
+
+        let mut conf_with_plaintext: Vec<u8> = encryption_result.confounder;
+        conf_with_plaintext.extend_from_slice(&plaintext);
+        let pad_len = (DES3_BLOCK_SIZE - (conf_with_plaintext.len() % DES3_BLOCK_SIZE)) % DES3_BLOCK_SIZE;
+        conf_with_plaintext.extend_from_slice(&vec![0; pad_len]);
+
+        assert_eq!(
+            hmac_sha1(&encryption_result.ki, &conf_with_plaintext, DES3_MAC_SIZE),
+            expected_encrypted_data_with_checksum[expected_encrypted_data_with_checksum.len() - DES3_MAC_SIZE..]
+        );
+
+        let mut cipher_data_with_checksum = encryption_result.encrypted;
+        cipher_data_with_checksum.extend(hmac_sha1(&encryption_result.ki, &conf_with_plaintext, DES3_MAC_SIZE));
+
+        assert_eq!(cipher_data_with_checksum, expected_encrypted_data_with_checksum);
+
+        assert_eq!(
+            cipher_data_with_checksum,
+            encrypt_message(&key, 5, &plaintext, confounder).unwrap()
+        );
+    }
+
+    #[test]
+    fn decrypt_with_checksum() {
+        let key = [
+            115, 248, 21, 32, 230, 42, 157, 138, 158, 254, 157, 145, 13, 110, 64, 107, 173, 206, 247, 93, 55, 146, 167,
+            138,
+        ];
+
+        let confounder = [161, 52, 157, 33, 238, 232, 185, 93];
+
+        let encrypted_with_checksum = &[
+            126, 136, 43, 80, 62, 251, 57, 122, 225, 31, 122, 177, 228, 203, 192, 209, 209, 50, 207, 26, 25, 42, 111,
+            102, 243, 28, 130, 32, 30, 129, 155, 136, 93, 10, 246, 56, 89, 215, 120, 254, 207, 136, 121, 74, 156, 20,
+            56, 227, 234, 98, 203, 221,
+        ];
+
+        let decryption_result = decrypt_message_no_checksum(&key, 5, encrypted_with_checksum).unwrap();
+
+        assert_eq!(
+            decrypt_message(&key, 5, encrypted_with_checksum).unwrap(),
+            decryption_result.plaintext
+        );
+
+        assert_eq!(confounder, decryption_result.confounder.as_slice());
+
+        let mut conf_with_padded_plaintext = decryption_result.confounder;
+        conf_with_padded_plaintext.extend(decryption_result.plaintext);
+
+        assert_eq!(
+            hmac_sha1(&decryption_result.ki, &conf_with_padded_plaintext, DES3_MAC_SIZE),
+            decryption_result.checksum
         );
     }
 }

--- a/picky-krb/src/crypto/des/encrypt.rs
+++ b/picky-krb/src/crypto/des/encrypt.rs
@@ -4,7 +4,7 @@ use des::TdesEde3;
 
 use crate::crypto::common::hmac_sha1;
 use crate::crypto::utils::{usage_ke, usage_ki};
-use crate::crypto::{KerberosCryptoError, KerberosCryptoResult};
+use crate::crypto::{EncryptWithoutChecksum, KerberosCryptoError, KerberosCryptoResult};
 
 use super::{derive_key, DES3_BLOCK_SIZE, DES3_KEY_SIZE, DES3_MAC_SIZE};
 
@@ -18,6 +18,33 @@ pub fn encrypt_message(
     // conf = Random string of length c
     confounder: [u8; DES3_BLOCK_SIZE],
 ) -> KerberosCryptoResult<Vec<u8>> {
+    let mut encryption_result = encrypt_message_no_checksum(key, key_usage, payload, confounder)?;
+    // prepare for checksum generation
+    let mut data_to_encrypt = vec![0; DES3_BLOCK_SIZE + payload.len()];
+
+    data_to_encrypt[0..DES3_BLOCK_SIZE].copy_from_slice(&confounder);
+    data_to_encrypt[DES3_BLOCK_SIZE..].copy_from_slice(payload);
+
+    let pad_len = (DES3_BLOCK_SIZE - (data_to_encrypt.len() % DES3_BLOCK_SIZE)) % DES3_BLOCK_SIZE;
+    // pad
+    data_to_encrypt.extend_from_slice(&vec![0; pad_len]);
+
+    let hmac = hmac_sha1(&encryption_result.ki, &data_to_encrypt, DES3_MAC_SIZE);
+
+    // ciphertext =  C1 | H1[1..h]
+    encryption_result.encrypted.extend_from_slice(&hmac);
+
+    Ok(encryption_result.encrypted)
+}
+
+// Returns (C1, conf, Ki)
+pub fn encrypt_message_no_checksum(
+    key: &[u8],
+    key_usage: i32,
+    payload: &[u8],
+    // conf = Random string of length c
+    confounder: [u8; DES3_BLOCK_SIZE],
+) -> KerberosCryptoResult<EncryptWithoutChecksum> {
     if key.len() != DES3_KEY_SIZE {
         return Err(KerberosCryptoError::KeyLength(key.len(), DES3_KEY_SIZE));
     }
@@ -33,16 +60,15 @@ pub fn encrypt_message(
 
     let ke = derive_key(key, &usage_ke(key_usage))?;
     // (C1, newIV) = E(Ke, conf | plaintext | pad, oldstate.ivec)
-    let mut encrypted = encrypt_des(&ke, &data_to_encrypt)?;
+    let encrypted = encrypt_des(&ke, &data_to_encrypt)?;
 
     let ki = derive_key(key, &usage_ki(key_usage))?;
-    // H1 = HMAC(Ki, conf | plaintext | pad)
-    let hmac = hmac_sha1(&ki, &data_to_encrypt, DES3_MAC_SIZE);
 
-    // ciphertext =  C1 | H1[1..h]
-    encrypted.extend_from_slice(&hmac);
-
-    Ok(encrypted)
+    Ok(EncryptWithoutChecksum {
+        encrypted,
+        confounder: confounder.to_vec(),
+        ki,
+    })
 }
 
 pub fn encrypt_des(key: &[u8], payload: &[u8]) -> KerberosCryptoResult<Vec<u8>> {

--- a/picky-krb/src/crypto/mod.rs
+++ b/picky-krb/src/crypto/mod.rs
@@ -49,6 +49,19 @@ impl From<PadError> for KerberosCryptoError {
     }
 }
 
+pub struct DecryptWithoutChecksum {
+    pub plaintext: Vec<u8>,
+    pub confounder: Vec<u8>,
+    pub checksum: Vec<u8>,
+    pub ki: Vec<u8>,
+}
+
+pub struct EncryptWithoutChecksum {
+    pub encrypted: Vec<u8>,
+    pub confounder: Vec<u8>,
+    pub ki: Vec<u8>,
+}
+
 pub type KerberosCryptoResult<T> = Result<T, KerberosCryptoError>;
 
 pub use checksum::{Checksum, ChecksumSuite};


### PR DESCRIPTION
Hi,
I added the possibility of Kerberos encryption but without a checksum. We need this functionality to support `SECBUFFER_READONLY` and `SECBUFFER_READONLY_WITH_CHECKSUM` flags for security buffers in `sspi-rs`. Related to: https://github.com/Devolutions/sspi-rs/issues/120 

Additionally, I reviewed the `crypto` module in `picky-krb`. It seems like Kerberos encryption algorithms were implemented a long time ago. We can refactor it by using [`cts`](https://docs.rs/cts/latest/cts/) and [`aes`](https://docs.rs/aes-gcm/latest/aes_gcm/) crates and get rid of the custom `cts` mode implementation. Let's create an issue for the future.

Docs & reference:

* [`SecBuffer` structure (sspi.h)](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secbuffer).