### PR TITLE
feat(picky-krb): implement `encryption_checksum` for krb ciphers

### DIFF
--- a/picky-krb/src/crypto/aes/aes128_cts_hmac_sha1_96.rs
+++ b/picky-krb/src/crypto/aes/aes128_cts_hmac_sha1_96.rs
@@ -1,6 +1,8 @@
 use rand::rngs::OsRng;
 use rand::Rng;
 
+use crate::crypto::common::hmac_sha1;
+use crate::crypto::utils::usage_ki;
 use crate::crypto::{
     ChecksumSuite, Cipher, CipherSuite, DecryptWithoutChecksum, EncryptWithoutChecksum, KerberosCryptoError,
     KerberosCryptoResult,
@@ -9,7 +11,7 @@ use crate::crypto::{
 use super::decrypt::{decrypt_message, decrypt_message_no_checksum};
 use super::encrypt::{encrypt_message, encrypt_message_no_checksum};
 use super::key_derivation::random_to_key;
-use super::{derive_key_from_password, AesSize, AES128_KEY_SIZE, AES_BLOCK_SIZE};
+use super::{derive_key, derive_key_from_password, AesSize, AES128_KEY_SIZE, AES_BLOCK_SIZE, AES_MAC_SIZE};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Aes128CtsHmacSha196;
@@ -73,6 +75,12 @@ impl Cipher for Aes128CtsHmacSha196 {
         cipher_data: &[u8],
     ) -> KerberosCryptoResult<DecryptWithoutChecksum> {
         decrypt_message_no_checksum(key, key_usage, cipher_data, &AesSize::Aes128)
+    }
+
+    fn encryption_checksum(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>> {
+        let ki = derive_key(key, &usage_ki(key_usage), &AesSize::Aes128)?;
+
+        Ok(hmac_sha1(&ki, payload, AES_MAC_SIZE))
     }
 
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>> {

--- a/picky-krb/src/crypto/cipher.rs
+++ b/picky-krb/src/crypto/cipher.rs
@@ -26,6 +26,11 @@ pub trait Cipher {
         cipher_data: &[u8],
     ) -> KerberosCryptoResult<DecryptWithoutChecksum>;
 
+    /// Calculates Kerberos checksum over the provided data.
+    ///
+    /// Note: the input `payload` should contain all data thar was used during encryption.
+    fn encryption_checksum(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
+
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
     fn random_to_key(&self, key: Vec<u8>) -> Vec<u8>;
 }

--- a/picky-krb/src/crypto/cipher.rs
+++ b/picky-krb/src/crypto/cipher.rs
@@ -28,7 +28,9 @@ pub trait Cipher {
 
     /// Calculates Kerberos checksum over the provided data.
     ///
-    /// Note: the input `payload` should contain all data thar was used during encryption.
+    /// Note: this method differs from [Checksum::checksum]. Key derivation processes for
+    /// encryption checksum and just checksum are different. More details:
+    /// * [Encryption and Checksum Specifications for Kerberos 5](https://datatracker.ietf.org/doc/html/rfc3961).
     fn encryption_checksum(&self, key: &[u8], key_usage: i32, payload: &[u8]) -> KerberosCryptoResult<Vec<u8>>;
 
     fn generate_key_from_password(&self, password: &[u8], salt: &[u8]) -> KerberosCryptoResult<Vec<u8>>;


### PR DESCRIPTION
Hi,
I implemented the `encryption_checksum` method for Kerberos ciphers. We need it to generate the Kerberos encryption checksum. However, the encryption checksum and regular Kebreros checksum key derivation methods are different. I added a comment with an explanation in the code.