### PR TITLE
fix: invalid parameters for ecdsa with sha512 serialization

### DIFF
--- a/picky-asn1-x509/src/algorithm_identifier.rs
+++ b/picky-asn1-x509/src/algorithm_identifier.rs
@@ -159,7 +159,7 @@ impl AlgorithmIdentifier {
     pub fn new_ecdsa_with_sha512() -> Self {
         Self {
             algorithm: oids::ecdsa_with_sha512().into(),
-            parameters: AlgorithmIdentifierParameters::Null,
+            parameters: AlgorithmIdentifierParameters::None,
         }
     }
 


### PR DESCRIPTION
When generation certificate with ecdsa sha512 the serialized version of the der in invalid and can not be parsed

here is an example that failed to parse a certificate just generated:
```rust
    let key = picky::key::PrivateKey::generate_ec(EcCurve::NistP521).unwrap();
    let root = CertificateBuilder::new()
        .validity(UtcDate::ymd(2020, 9, 28).unwrap(), UtcDate::ymd(2023, 9, 28).unwrap())
        .self_signed(DirectoryName::new_common_name("My Root CA"), &key)
        .ca(true)
        .signature_hash_type(SignatureAlgorithm::Ecdsa(HashAlgorithm::SHA2_512))
        // .key_id_gen_method(KeyIdGenMethod::SPKFullDER(HashAlgorithm::SHA2_384))
        .build()
        .unwrap();
    
    let der = root.to_der().unwrap();

    dbg!(Cert::from_der(&der)).unwrap();
```

this throw an error

```
Cert::from_der(&der) = Err(
    Asn1Deserialization {
        element: "x509 certificate",
        source: InvalidData,
    },
)
```