### PR TITLE
fix(picky-krb): `EncTicketPart` structure;

### DIFF
--- a/picky-krb/src/constants.rs
+++ b/picky-krb/src/constants.rs
@@ -36,8 +36,10 @@ pub mod types {
     pub const PA_PK_AS_REQ: [u8; 1] = [0x10];
     pub const PA_PK_AS_REP: [u8; 1] = [17];
 
+    //= [Application Tag Numbers](https://www.rfc-editor.org/rfc/rfc4120#section-5.10) =//
     pub const TICKET_TYPE: u8 = 1;
     pub const AUTHENTICATOR_TYPE: u8 = 2;
+    pub const ENC_TICKET_PART_TYPE: u8 = 3;
     pub const ENC_AS_REP_PART_TYPE: u8 = 25;
     pub const ENC_TGS_REP_PART_TYPE: u8 = 26;
     pub const ENC_AP_REP_PART_TYPE: u8 = 27;

--- a/picky-krb/src/data_types.rs
+++ b/picky-krb/src/data_types.rs
@@ -14,7 +14,9 @@ use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::{fmt, io};
 
-use crate::constants::types::{AUTHENTICATOR_TYPE, ENC_AP_REP_PART_TYPE, KRB_PRIV_ENC_PART, TICKET_TYPE};
+use crate::constants::types::{
+    AUTHENTICATOR_TYPE, ENC_AP_REP_PART_TYPE, ENC_TICKET_PART_TYPE, KRB_PRIV_ENC_PART, TICKET_TYPE,
+};
 use crate::messages::KrbError;
 
 /// [RFC 4120 5.2.1](https://www.rfc-editor.org/rfc/rfc4120.txt)
@@ -197,7 +199,7 @@ pub struct TransitedEncoding {
 /// }
 /// ```
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-pub struct EncTicketPart {
+pub struct EncTicketPartInner {
     pub flags: ExplicitContextTag0<KerberosFlags>,
     pub key: ExplicitContextTag1<EncryptionKey>,
     pub crealm: ExplicitContextTag2<Realm>,
@@ -213,6 +215,8 @@ pub struct EncTicketPart {
     #[serde(default)]
     pub authorization_data: Optional<Option<ExplicitContextTag10<AuthorizationData>>>,
 }
+
+pub type EncTicketPart = ApplicationTag<EncTicketPartInner, ENC_TICKET_PART_TYPE>;
 
 /// [RFC 4120 5.4.2](https://www.rfc-editor.org/rfc/rfc4120.txt)
 ///


### PR DESCRIPTION
Hi,
During dev testing and debugging I noticed that the `sspi-rs` cannot parse the decrypted ticket data generated by the KDC. After that, I discovered that the `EncTicketPart` structure is defined incorrectly in `picky-krb`.