### PR TITLE
build: optimize binary size for FFI builds

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -164,7 +164,8 @@ jobs:
           $CargoParams = @(
               "build",
               "-p", "picky-ffi",
-              "--release",
+              "--profile",
+              "ffi-production",
               "--target", "$RustTarget"
           )
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,55 @@ default-members = [
     "picky-asn1-der",
     "picky-asn1-x509",
 ]
+
+[profile.ffi-production]
+inherits = "release"
+strip = "symbols"
+lto = true
+opt-level = "z"
+codegen-units = 1
+panic = "abort"
+
+# Optimize for speed the cryptographic libraries.
+[profile.ffi-production.package.num-bigint-dig]
+opt-level = 3
+[profile.ffi-production.package.ed25519-dalek]
+opt-level = 3
+[profile.ffi-production.package.x25519-dalek]
+opt-level = 3
+[profile.ffi-production.package.p256]
+opt-level = 3
+[profile.ffi-production.package.p384]
+opt-level = 3
+[profile.ffi-production.package.p521]
+opt-level = 3
+[profile.ffi-production.package.rsa]
+opt-level = 3
+[profile.ffi-production.package.sha1]
+opt-level = 3
+[profile.ffi-production.package.sha2]
+opt-level = 3
+[profile.ffi-production.package.sha3]
+opt-level = 3
+[profile.ffi-production.package.aes-gcm]
+opt-level = 3
+[profile.ffi-production.package.aes]
+opt-level = 3
+[profile.ffi-production.package.aes-kw]
+opt-level = 3
+[profile.ffi-production.package.argon2]
+opt-level = 3
+[profile.ffi-production.package.ctr]
+opt-level = 3
+[profile.ffi-production.package.cbc]
+opt-level = 3
+[profile.ffi-production.package.bcrypt-pbkdf]
+opt-level = 3
+[profile.ffi-production.package.des]
+opt-level = 3
+[profile.ffi-production.package.rc2]
+opt-level = 3
+[profile.ffi-production.package.pbkdf2]
+opt-level = 3
+[profile.ffi-production.package.hmac]
+opt-level = 3


### PR DESCRIPTION
Aim for good balance between size and performance.

- Baseline: 7.4M
- strip = "symbols": 6.0M
- lto = true: 4.7M
- opt-level = "z": 3.5M
- codegen-units = 1: 3.3M
- panic = "abort": 3.0M
- opt-level = 3 for crypto libs: 3.1M