### PR TITLE
ci(nuget): set MACOSX_DEPLOYMENT_TARGET to 10.12

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -98,7 +98,7 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ matrix.os }}' -Eq 'osx') {
-            echo "MACOSX_DEPLOYMENT_TARGET=10.10" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            echo "MACOSX_DEPLOYMENT_TARGET=10.12" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           } elseif ('${{ matrix.os }}' -Eq 'ios') {
             echo "IPHONEOS_DEPLOYMENT_TARGET=12.1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           }


### PR DESCRIPTION
Fixes the following warning:

```
warning: deployment target in MACOSX_DEPLOYMENT_TARGET was set to 10.10, but the minimum supported by `rustc` is 10.12
```