### PR TITLE
fix: use published `rc2` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,8 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "rc2"
-version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers?rev=cbc75f837701a1114bd50748cff6cdb65e8d3c1d#cbc75f837701a1114bd50748cff6cdb65e8d3c1d"
+version = "0.9.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03621ac292cc723def9e0fd0eb9573b1df8d6a9ee7ad637fe94dfc153705f3c"
 dependencies = [
  "cipher",
 ]

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -72,7 +72,7 @@ ctr = { version = "0.10.0-rc.1", optional = true }
 cbc = { version = "0.2.0-rc.1", optional = true, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11.0-rc.1", optional = true }
 des = { version = "0.9.0-rc.1", optional = true }
-rc2 = { git = "https://github.com/RustCrypto/block-ciphers", rev = "cbc75f837701a1114bd50748cff6cdb65e8d3c1d", optional = true } # We need the new version, but it's not released yet.
+rc2 = { version = "0.9.0-pre.0", optional = true }
 pbkdf2 = { version = "0.13.0-rc.1", optional = true }
 hmac = { version = "0.13.0-rc.1", optional = true }
 inout = "0.2.0-rc.6"


### PR DESCRIPTION
Finally, unblocks the next release of picky-rs crates. 