### PR TITLE
fix: pin RustCrypto release candidate crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -510,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.14"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae7ba52b8bca06caab3e74b7cf8858a2934e6e75d80b03dbe48d2d394a4489c"
+checksum = "2e3be87c458d756141f3b6ee188828132743bf90c7d14843e2835d6443e5fb03"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -521,6 +522,7 @@ dependencies = [
  "group",
  "hkdf",
  "hybrid-array",
+ "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.9.3",
@@ -1325,54 +1327,80 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "picky"
 version = "7.0.0-rc.18"
 dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
  "aes-kw",
  "argon2",
  "base64",
  "bcrypt-pbkdf",
+ "blake2",
+ "block-buffer",
+ "block-padding",
+ "blowfish",
  "byteorder",
  "cab",
  "cbc",
  "cfg-if",
  "chrono",
+ "cipher",
  "crypto-bigint",
+ "crypto-common",
  "ctr",
+ "der",
  "des",
  "digest",
+ "ecdsa",
+ "ed25519",
  "ed25519-dalek",
+ "elliptic-curve",
  "expect-test",
+ "ghash",
  "hex",
+ "hkdf",
  "hmac",
  "http",
  "inout",
+ "keccak",
  "lexical-sort",
  "md-5",
  "p256",
  "p384",
  "p521",
+ "password-hash",
  "pbkdf2",
+ "pem-rfc7468",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "picky-test-data",
+ "pkcs1",
+ "pkcs8",
+ "polyval",
  "pretty_assertions",
+ "primefield",
+ "primeorder",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "rc2",
  "reqwest",
+ "rfc6979",
  "ring",
  "rsa",
  "rstest",
+ "sec1",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
  "sha3",
+ "signature",
+ "spki",
  "tempfile",
  "thiserror",
  "time",
+ "universal-hash",
  "x25519-dalek",
  "zeroize",
 ]
@@ -1446,10 +1474,15 @@ name = "picky-krb"
 version = "0.11.2"
 dependencies = [
  "aes",
+ "block-buffer",
+ "block-padding",
  "byteorder",
  "cbc",
+ "cipher",
  "crypto-bigint",
+ "crypto-common",
  "des",
+ "digest",
  "hmac",
  "inout",
  "oid",

--- a/ffi/wasm/Cargo.lock
+++ b/ffi/wasm/Cargo.lock
@@ -325,6 +325,7 @@ version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -344,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.14"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae7ba52b8bca06caab3e74b7cf8858a2934e6e75d80b03dbe48d2d394a4489c"
+checksum = "2e3be87c458d756141f3b6ee188828132743bf90c7d14843e2835d6443e5fb03"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -355,6 +356,7 @@ dependencies = [
  "group",
  "hkdf",
  "hybrid-array",
+ "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.9.3",
@@ -683,6 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
 dependencies = [
  "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -710,38 +713,65 @@ dependencies = [
 name = "picky"
 version = "7.0.0-rc.18"
 dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
  "aes-kw",
  "argon2",
  "base64",
  "bcrypt-pbkdf",
+ "blake2",
+ "block-buffer",
+ "block-padding",
+ "blowfish",
  "byteorder",
  "cbc",
+ "cipher",
  "crypto-bigint",
+ "crypto-common",
  "ctr",
+ "der",
  "digest",
+ "ecdsa",
+ "ed25519",
  "ed25519-dalek",
+ "elliptic-curve",
+ "ghash",
  "hex",
+ "hkdf",
  "hmac",
  "inout",
+ "keccak",
  "lexical-sort",
  "md-5",
  "p256",
  "p384",
  "p521",
+ "password-hash",
+ "pbkdf2",
+ "pem-rfc7468",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
+ "pkcs1",
+ "pkcs8",
+ "polyval",
+ "primefield",
+ "primeorder",
  "rand 0.9.2",
  "rand_core 0.9.3",
+ "rfc6979",
  "rsa",
+ "sec1",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
  "sha3",
+ "signature",
+ "spki",
  "thiserror",
+ "universal-hash",
  "x25519-dalek",
  "zeroize",
 ]

--- a/picky-krb/Cargo.toml
+++ b/picky-krb/Cargo.toml
@@ -20,16 +20,24 @@ serde = { version = "1", features = ["derive"] }
 byteorder = "1.5"
 thiserror = "1"
 
-pbkdf2 = { version = "0.13.0-rc.1", features = ["sha1"] }
-hmac = "0.13.0-rc.1"
-sha1 = "0.11.0-rc.2"
+pbkdf2 = { version = "=0.13.0-rc.1", features = ["sha1"] }
+hmac = "=0.13.0-rc.2"
+sha1 = "=0.11.0-rc.2"
 
-aes = "0.9.0-rc.1"
-des = "0.9.0-rc.1"
-cbc = "0.2.0-rc.1"
-inout = "0.2.0-rc.6"
+aes = "=0.9.0-rc.1"
+des = "=0.9.0-rc.1"
+cbc = "=0.2.0-rc.1"
+inout = "=0.2.0-rc.6"
 rand = "0.9"
 
 uuid = { version = "1.18", default-features = false, features = ["serde"] }
 oid = "0.2"
-crypto-bigint = { version = "0.7.0-rc.6", features = ["alloc"] }
+crypto-bigint = { version = "=0.7.0-rc.8", features = ["alloc"] }
+
+# Pin transitive dependencies versions.
+# TODO: Remove when stable versions will be released.
+block-padding = "=0.4.0-rc.4"
+cipher = "=0.5.0-rc.1"
+block-buffer = "=0.11.0-rc.5"
+crypto-common = "=0.2.0-rc.4"
+digest = "=0.11.0-rc.3"

--- a/picky/Cargo.toml
+++ b/picky/Cargo.toml
@@ -47,35 +47,64 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking"],
 
 rand = "0.9"
 rand_core = "0.9"
-crypto-bigint = "0.7.0-rc.6"
+crypto-bigint = "=0.7.0-rc.8"
 
-ed25519-dalek = { version = "3.0.0-pre.1", features = ["hazmat", "rand_core"] }
-x25519-dalek = { version = "3.0.0-pre.1", features = ["static_secrets"] }
+ed25519-dalek = { version = "=3.0.0-pre.1", features = ["hazmat", "rand_core"] }
+x25519-dalek = { version = "=3.0.0-pre.1", features = ["static_secrets"] }
 
-p256 = { version = "0.14.0-pre.11", features = ["ecdh"] }
-p384 = { version = "0.14.0-pre.11", features = ["ecdh"] }
-p521 = { version = "0.14.0-pre.11", features = ["ecdh"] }
+p256 = { version = "=0.14.0-pre.11", features = ["ecdh"] }
+p384 = { version = "=0.14.0-pre.11", features = ["ecdh"] }
+p521 = { version = "=0.14.0-pre.11", features = ["ecdh"] }
 
-rsa = { version = "0.10.0-rc.9", features = ["std"] }
+rsa = { version = "=0.10.0-rc.9", features = ["std"] }
 
-digest = "0.11.0-rc.3"
-md5 = { package = "md-5", version = "0.11.0-rc.2", features = ["oid"] }
-sha1 = { version = "0.11.0-rc.2", features = ["oid"] }
-sha2 = { version = "0.11.0-rc.2", features = ["oid"] }
-sha3 = { version = "0.11.0-rc.3", features = ["oid"] }
+digest = "=0.11.0-rc.3"
+md5 = { package = "md-5", version = "=0.11.0-rc.2", features = ["oid"] }
+sha1 = { version = "=0.11.0-rc.2", features = ["oid"] }
+sha2 = { version = "=0.11.0-rc.2", features = ["oid"] }
+sha3 = { version = "=0.11.0-rc.3", features = ["oid"] }
 
-aes-gcm = { version = "0.11.0-rc.1", optional = true }
-aes = { version = "0.9.0-rc.1", optional = true }
-aes-kw = { version = "0.3.0-rc.1", optional = true }
-argon2 = { version = "0.6.0-rc.1", optional = true }
-ctr = { version = "0.10.0-rc.1", optional = true }
-cbc = { version = "0.2.0-rc.1", optional = true, features = ["alloc"] }
-bcrypt-pbkdf = { version = "0.11.0-rc.1", optional = true }
-des = { version = "0.9.0-rc.1", optional = true }
-rc2 = { version = "0.9.0-pre.0", optional = true }
-pbkdf2 = { version = "0.13.0-rc.1", optional = true }
-hmac = { version = "0.13.0-rc.1", optional = true }
-inout = "0.2.0-rc.6"
+aes-gcm = { version = "=0.11.0-rc.1", optional = true }
+aes = { version = "=0.9.0-rc.1", optional = true }
+aes-kw = { version = "=0.3.0-rc.1", optional = true }
+argon2 = { version = "=0.6.0-rc.1", optional = true }
+ctr = { version = "=0.10.0-rc.1", optional = true }
+cbc = { version = "=0.2.0-rc.1", optional = true, features = ["alloc"] }
+bcrypt-pbkdf = { version = "=0.11.0-rc.1", optional = true }
+des = { version = "=0.9.0-rc.1", optional = true }
+rc2 = { version = "=0.9.0-pre.0", optional = true }
+pbkdf2 = { version = "=0.13.0-rc.1", optional = true }
+hmac = { version = "=0.13.0-rc.2", optional = true }
+inout = "=0.2.0-rc.6"
+
+# Pin transitive dependencies versions.
+# TODO: Remove when stable versions will be released.
+aead = { version = "=0.6.0-rc.2", optional = true }
+blake2 = { version = "=0.11.0-rc.2", optional = true }
+block-padding = "=0.4.0-rc.4"
+block-buffer = "=0.11.0-rc.5"
+blowfish = { version = "=0.10.0-rc.1", optional = true }
+cipher = { version = "=0.5.0-rc.1", optional = true }
+crypto-common = "=0.2.0-rc.4"
+ghash = { version = "=0.6.0-rc.2", optional = true }
+polyval = { version = "=0.7.0-rc.2", optional = true }
+universal-hash = { version = "=0.6.0-rc.2", optional = true }
+password-hash = { version = "=0.6.0-rc.1", optional = true }
+ed25519 = "=3.0.0-rc.1"
+signature = "=3.0.0-rc.4"
+ecdsa = "=0.17.0-rc.7"
+der = "=0.8.0-rc.9"
+pem-rfc7468 = "=1.0.0-rc.3"
+elliptic-curve = "=0.14.0-rc.15"
+hkdf = "=0.13.0-rc.2"
+pkcs8 = "=0.11.0-rc.7"
+spki = "=0.8.0-rc.4"
+sec1 = "=0.8.0-rc.10"
+rfc6979 = "=0.5.0-rc.1"
+pkcs1 = "=0.8.0-rc.4"
+keccak = "=0.2.0-rc.0"
+primefield = "=0.14.0-pre.6"
+primeorder = "=0.14.0-pre.9"
 
 [dev-dependencies]
 pretty_assertions = "1.4"
@@ -92,9 +121,15 @@ default = ["x509", "jose", "http_signature", "http_trait_impl", "pkcs12"]
 
 # main features
 x509 = []
-jose = ["dep:serde_json", "dep:aes-gcm", "dep:cbc", "dep:aes-kw"]
+jose = ["dep:serde_json", "dep:aes-gcm", "dep:cbc", "dep:aes-kw",
+# Transitive dependencies
+    "dep:aead", "dep:aes", "dep:cipher", "dep:ctr", "dep:ghash", "dep:polyval", "dep:universal-hash"
+]
 http_signature = []
-pkcs12 = ["picky-asn1-x509/pkcs12", "dep:des", "dep:rc2", "dep:cbc", "dep:pbkdf2", "dep:hmac", "dep:aes", "x509"]
+pkcs12 = ["picky-asn1-x509/pkcs12", "dep:des", "dep:rc2", "dep:cbc", "dep:pbkdf2", "dep:hmac", "dep:aes", "x509",
+# Transitive dependencies
+    "dep:cipher"
+]
 
 # secondary features
 pkcs7 = ["x509", "picky-asn1-x509/pkcs7"]
@@ -102,11 +137,17 @@ http_timestamp = ["dep:reqwest"]
 ctl = ["picky-asn1-x509/ctl", "pkcs7", "chrono_conversion"]
 ctl_http_fetch = ["dep:reqwest", "dep:cab", "ctl"]
 wincert = ["x509", "dep:byteorder"]
-ssh = ["dep:byteorder", "dep:aes", "dep:ctr", "dep:cbc", "dep:bcrypt-pbkdf", "dep:lexical-sort"]
+ssh = ["dep:byteorder", "dep:aes", "dep:ctr", "dep:cbc", "dep:bcrypt-pbkdf", "dep:lexical-sort",
+# Transitive dependencies
+    "dep:cipher", "dep:blowfish", "dep:pbkdf2", "dep:hmac"
+]
 http_trait_impl = ["dep:http"]
 chrono_conversion = ["dep:chrono", "picky-asn1/chrono_conversion"]
 time_conversion = ["dep:time", "picky-asn1/time_conversion"]
-putty = ["dep:argon2", "dep:hmac", "ssh"]
+putty = ["dep:argon2", "dep:hmac", "ssh",
+# Transitive dependencies
+    "dep:blake2", "dep:password-hash"
+]
 
 [package.metadata.docs.rs]
 # Enable all features when building documentation for docs.rs

--- a/picky/src/signature.rs
+++ b/picky/src/signature.rs
@@ -3,7 +3,6 @@
 use crate::hash::HashAlgorithm;
 use crate::key::ec::{EcComponent, EcCurve, NamedEcCurve};
 use crate::key::{KeyError, PrivateKey, PublicKey};
-use ed25519_dalek::ed25519::SignatureEncoding;
 use rsa::signature::Signer;
 
 use picky_asn1_x509::{AlgorithmIdentifier, oids};


### PR DESCRIPTION
The patch version upgrade is not allowed to bring breaking changes, but this rule doesn't work for an `rc` version. So we should pin the `rc` versions, to not allow _cargo_ update to a new `rc` automatically. 
Seems like RustCrypto will have release of all crates (really soon)[https://github.com/RustCrypto/AEADs/issues/726#issuecomment-3348738331]. This hotfix won't live a long time. Here is the tracking issue for it - https://github.com/RustCrypto/traits/issues/1571. 

Fixes #416. 