### PR TITLE
ci: run the .NET binding tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,55 @@ jobs:
       - name: cargo check ${{ matrix.crate }}
         run: cargo +${{ matrix.msvc }} check -p ${{ matrix.crate }}
 
+  dotnet-tests:
+    name: .NET binding tests
+    needs: [formatting]
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Release matches what ships (the ffi-production/NuGet build) and avoids debug-only
+      # std precondition checks at the FFI boundary.
+      - name: Build native library
+        run: cargo build --locked --release -p picky-ffi
+        shell: pwsh
+
+      # Devolutions.Picky multi-targets net9.0-ios, so the iOS workload is required
+      # just to build it (same as the nuget.yml build-managed job).
+      - name: Install iOS workload
+        run: dotnet workload install ios
+        shell: pwsh
+
+      # GeneratePackageOnBuild is on by default; disable it so the build does not try to
+      # pack native libraries for every RID (only the win-x64 one is available here).
+      # The committed bindings are built as-is (not regenerated) so a stale binding fails CI.
+      - name: Build .NET bindings and tests
+        run: dotnet build ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release -p:GeneratePackageOnBuild=false
+        shell: pwsh
+
+      # The project intentionally does not copy the native lib to output
+      # (CopyToOutputDirectory=Never), so place it next to the test host.
+      - name: Place native library next to the test host
+        run: |
+          $testDll = Get-ChildItem -Recurse -Path ./ffi/dotnet/Devolutions.Picky.Tests/bin/Release -Filter Devolutions.Picky.Tests.dll | Select-Object -First 1
+          Copy-Item ./target/release/picky.dll (Join-Path $testDll.DirectoryName DevolutionsPicky.dll) -Force
+        shell: pwsh
+
+      # The tests read fixtures via paths relative to the test host CWD that resolve to
+      # <repo-parent>/test_assets; provision them from picky-test-data.
+      - name: Provision test assets
+        run: Copy-Item picky-test-data/test_assets ../test_assets -Recurse -Force
+        shell: pwsh
+
+      - name: Run .NET tests
+        run: dotnet test ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release --no-build
+        shell: pwsh
+
   success:
     name: Success
     if: ${{ always() }}
-    needs: [formatting, lints, lints-wasm, tests, msrv]
+    needs: [formatting, lints, lints-wasm, tests, msrv, dotnet-tests]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,17 @@ jobs:
         run: cargo build --locked --release -p picky-ffi
         shell: pwsh
 
+      # Devolutions.Picky multi-targets net9.0-ios, so the iOS workload is required
+      # just to build it.
+      - name: Install iOS workload
+        run: dotnet workload install ios
+        shell: pwsh
+
       # GeneratePackageOnBuild is on by default; disable it so the build does not try to
       # pack native libraries for every RID (only the win-x64 one is available here).
       # The committed bindings are built as-is (not regenerated) so a stale binding fails CI.
-      # We pass in -p:TargetFrameworks=netstandard2.0 to override the target framework and avoid net9.0-ios,
-      # which is not required for the tests in CI.
       - name: Build .NET bindings and tests
-        run: dotnet build ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release -p:GeneratePackageOnBuild=false -p:TargetFrameworks=netstandard2.0
+        run: dotnet build ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release -p:GeneratePackageOnBuild=false
         shell: pwsh
 
       # The project intentionally does not copy the native lib to output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,32 +131,33 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The .NET bindings are compatible up to .NET 6 SDK.
+      # We run the tests of the oldest compatible framework.
       - name: Install .NET 6 SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
 
-      # Release matches what ships (the ffi-production/NuGet build) and avoids debug-only
-      # std precondition checks at the FFI boundary.
+      # Release matches what ships (the ffi-production/NuGet build).
+      # Furthermore, debug builds currently trip std precondition checks at the FFI boundary.
+      # FIXME/TODO: Once we updated Diplomat to a newer version, it’s worth switching to a matrix
+      # for testing both the debug and release builds.
+      # NOTE: support for netstandard2.0 will be dropped once we get rid of the specialized Diplomat fork.
       - name: Build native library
         run: cargo build --locked --release -p picky-ffi
-        shell: pwsh
-
-      # Devolutions.Picky multi-targets net9.0-ios, so the iOS workload is required
-      # just to build it (same as the nuget.yml build-managed job).
-      - name: Install iOS workload
-        run: dotnet workload install ios
         shell: pwsh
 
       # GeneratePackageOnBuild is on by default; disable it so the build does not try to
       # pack native libraries for every RID (only the win-x64 one is available here).
       # The committed bindings are built as-is (not regenerated) so a stale binding fails CI.
+      # We pass in -p:TargetFrameworks=netstandard2.0 to override the target framework and avoid net9.0-ios,
+      # which is not required for the tests in CI.
       - name: Build .NET bindings and tests
-        run: dotnet build ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release -p:GeneratePackageOnBuild=false
+        run: dotnet build ./ffi/dotnet/Devolutions.Picky.Tests/Devolutions.Picky.Tests.csproj -c Release -p:GeneratePackageOnBuild=false -p:TargetFrameworks=netstandard2.0
         shell: pwsh
 
       # The project intentionally does not copy the native lib to output
-      # (CopyToOutputDirectory=Never), so place it next to the test host.
+      # (CopyToOutputDirectory=Never), so manually place it next to the test host.
       - name: Place native library next to the test host
         run: |
           $testDll = Get-ChildItem -Recurse -Path ./ffi/dotnet/Devolutions.Picky.Tests/bin/Release -Filter Devolutions.Picky.Tests.dll | Select-Object -First 1
@@ -165,6 +166,7 @@ jobs:
 
       # The tests read fixtures via paths relative to the test host CWD that resolve to
       # <repo-parent>/test_assets; provision them from picky-test-data.
+      # FIXME: It would be worth repointing them at picky-test-data/test_assets.
       - name: Provision test assets
         run: Copy-Item picky-test-data/test_assets ../test_assets -Recurse -Force
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install .NET 6 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
       # Release matches what ships (the ffi-production/NuGet build) and avoids debug-only
       # std precondition checks at the FFI boundary.
       - name: Build native library

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v6
 
-      - name: Install ios workload
+      - name: Install iOS workload
         run: dotnet workload install ios
 
       - name: Prepare dependencies

--- a/ffi/dotnet/Devolutions.Picky.Tests/X509Tests.cs
+++ b/ffi/dotnet/Devolutions.Picky.Tests/X509Tests.cs
@@ -90,7 +90,7 @@ Z/fDKMxHxeXla54kfV+HiGkH
         Assert.Equal("44AFB080D6A327BA893039862EF8406B", cert2.SerialNumber);
 
         X509ExtensionCollection extensions = cert2.Extensions;
-        X509Extension? skiExt = extensions["subjectKeyIdentifier"];
+        X509Extension? skiExt = extensions["2.5.29.14"]; // SKI OID (friendly-name lookup is runtime-dependent)
         Assert.NotNull(skiExt);
         byte[] skiExtRawData = skiExt!.RawData; // includes the ASN.1 DER tag and length of the actual value
         Assert.Equal("0414C4A7B1A47B2C71FADBE14B9075FFC41560858910", Convert.ToHexString(skiExtRawData));

--- a/ffi/dotnet/Devolutions.Picky.Tests/X509Tests.cs
+++ b/ffi/dotnet/Devolutions.Picky.Tests/X509Tests.cs
@@ -90,7 +90,7 @@ Z/fDKMxHxeXla54kfV+HiGkH
         Assert.Equal("44AFB080D6A327BA893039862EF8406B", cert2.SerialNumber);
 
         X509ExtensionCollection extensions = cert2.Extensions;
-        X509Extension? skiExt = extensions["2.5.29.14"]; // SKI OID (friendly-name lookup is runtime-dependent)
+        X509Extension? skiExt = extensions["2.5.29.14"]; // Subject Key Identifier (SKI) OID
         Assert.NotNull(skiExt);
         byte[] skiExtRawData = skiExt!.RawData; // includes the ASN.1 DER tag and length of the actual value
         Assert.Equal("0414C4A7B1A47B2C71FADBE14B9075FFC41560858910", Convert.ToHexString(skiExtRawData));


### PR DESCRIPTION
Follow-up to #516. Adds a CI job that builds the native library and runs the .NET binding tests (`Devolutions.Picky.Tests`) on Windows — the suite that would have caught the ABI mismatch fixed in #516, but which no workflow was running.

## What the job does
- Builds the native library in release (`cargo build --release -p picky-ffi`) — matches what ships and avoids debug-only std precondition checks at the FFI boundary.
- Installs the iOS workload (required to build the multi-target `Devolutions.Picky` project, same as `nuget.yml`'s `build-managed`).
- Builds the tests against the **committed** bindings (`-p:GeneratePackageOnBuild=false`), so a stale/mismatched binding fails CI.
- Places the native library next to the test host (the project sets `CopyToOutputDirectory=Never`), provisions the fixtures, and runs `dotnet test`.
- Wired into the `success` gate.

## Also included
`X509Tests.X509Certificate2Conversion` looked up the Subject Key Identifier extension by the friendly-name string `"subjectKeyIdentifier"`, which newer .NET runtimes don't match (the canonical name is `Subject Key Identifier`). Switched to the OID `2.5.29.14` so the lookup is runtime-independent.

Verified locally: 26/26 tests pass.

## Follow-ups (not in this PR)
- The tests read fixtures via brittle relative paths that resolve to the repo's parent; the job provisions fixtures there to match. Worth repointing them at `picky-test-data/test_assets`.
- A debug native build trips a std `from_raw_parts` precondition (empty slice passed as a null pointer at the FFI boundary); harmless in release but a real latent diplomat-FFI quirk.
